### PR TITLE
Update CI and fix Clippy lints

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,10 +5,8 @@ cargo_cache:
 task:
   env:
     HOME: /tmp # cargo cache needs it
-    # Temporary workaround for https://github.com/rust-lang/rustup/issues/2774
-    RUSTUP_IO_THREADS: 1
   freebsd_instance:
-    image: freebsd-11-4-release-amd64
+    image: freebsd-12-3-release-amd64
   matrix:
     - name: FreeBSD stable
       env:

--- a/src/libxfuse/attr.rs
+++ b/src/libxfuse/attr.rs
@@ -296,15 +296,15 @@ impl AttrLeafblock {
             if entry.flags & XFS_ATTR_LOCAL == 0 {
                 let name_entry = AttrLeafNameLocal::from(buf_reader.by_ref());
 
-                list.extend_from_slice(&get_namespace_from_flags(entry.flags).as_bytes().to_vec());
+                list.extend_from_slice(get_namespace_from_flags(entry.flags).as_bytes());
                 let namelen = name_entry.namelen as usize;
-                list.extend_from_slice(&name_entry.nameval[0..namelen].to_vec());
+                list.extend_from_slice(&name_entry.nameval[0..namelen]);
             } else {
                 let name_entry = AttrLeafNameRemote::from(buf_reader.by_ref());
 
-                list.extend_from_slice(&get_namespace_from_flags(entry.flags).as_bytes().to_vec());
+                list.extend_from_slice(get_namespace_from_flags(entry.flags).as_bytes());
                 let namelen = name_entry.namelen as usize;
-                list.extend_from_slice(&name_entry.name[0..namelen].to_vec());
+                list.extend_from_slice(&name_entry.name[0..namelen]);
             }
 
             list.push(0)

--- a/src/libxfuse/attr_bptree.rs
+++ b/src/libxfuse/attr_bptree.rs
@@ -49,16 +49,16 @@ impl<R: BufRead + Seek> Attr<R> for AttrBtree {
         if self.total_size == -1 {
             let mut total_size: u32 = 0;
 
-            let blk = self.btree.map_block(buf_reader.by_ref(), &super_block, 0);
+            let blk = self.btree.map_block(buf_reader.by_ref(), super_block, 0);
             buf_reader
                 .seek(SeekFrom::Start(blk * u64::from(super_block.sb_blocksize)))
                 .unwrap();
 
             let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
 
-            let blk = node.first_block(buf_reader.by_ref(), &super_block, |block, reader| {
+            let blk = node.first_block(buf_reader.by_ref(), super_block, |block, reader| {
                 self.btree
-                    .map_block(reader.by_ref(), &super_block, block.into())
+                    .map_block(reader.by_ref(), super_block, block.into())
             });
             let leaf_offset = blk * u64::from(super_block.sb_blocksize);
 
@@ -81,16 +81,16 @@ impl<R: BufRead + Seek> Attr<R> for AttrBtree {
     fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &str) -> u32 {
         let hash = hashname(name);
 
-        let blk = self.btree.map_block(buf_reader.by_ref(), &super_block, 0);
+        let blk = self.btree.map_block(buf_reader.by_ref(), super_block, 0);
         buf_reader
             .seek(SeekFrom::Start(blk * u64::from(super_block.sb_blocksize)))
             .unwrap();
 
         let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
 
-        let blk = node.lookup(buf_reader.by_ref(), &super_block, hash, |block, reader| {
+        let blk = node.lookup(buf_reader.by_ref(), super_block, hash, |block, reader| {
             self.btree
-                .map_block(reader.by_ref(), &super_block, block.into())
+                .map_block(reader.by_ref(), super_block, block.into())
         });
         let leaf_offset = blk * u64::from(super_block.sb_blocksize);
 
@@ -103,18 +103,18 @@ impl<R: BufRead + Seek> Attr<R> for AttrBtree {
 
     fn list(&mut self, buf_reader: &mut R, super_block: &Sb) -> Vec<u8> {
         let mut list: Vec<u8> =
-            Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), &super_block) as usize);
+            Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), super_block) as usize);
 
-        let blk = self.btree.map_block(buf_reader.by_ref(), &super_block, 0);
+        let blk = self.btree.map_block(buf_reader.by_ref(), super_block, 0);
         buf_reader
             .seek(SeekFrom::Start(blk * u64::from(super_block.sb_blocksize)))
             .unwrap();
 
         let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
 
-        let blk = node.first_block(buf_reader.by_ref(), &super_block, |block, reader| {
+        let blk = node.first_block(buf_reader.by_ref(), super_block, |block, reader| {
             self.btree
-                .map_block(reader.by_ref(), &super_block, block.into())
+                .map_block(reader.by_ref(), super_block, block.into())
         });
         let leaf_offset = blk * u64::from(super_block.sb_blocksize);
 
@@ -134,16 +134,16 @@ impl<R: BufRead + Seek> Attr<R> for AttrBtree {
     fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &str) -> Vec<u8> {
         let hash = hashname(name);
 
-        let blk = self.btree.map_block(buf_reader.by_ref(), &super_block, 0);
+        let blk = self.btree.map_block(buf_reader.by_ref(), super_block, 0);
         buf_reader
             .seek(SeekFrom::Start(blk * u64::from(super_block.sb_blocksize)))
             .unwrap();
 
         let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
 
-        let blk = node.lookup(buf_reader.by_ref(), &super_block, hash, |block, reader| {
+        let blk = node.lookup(buf_reader.by_ref(), super_block, hash, |block, reader| {
             self.btree
-                .map_block(reader.by_ref(), &super_block, block.into())
+                .map_block(reader.by_ref(), super_block, block.into())
         });
         let leaf_offset = blk * u64::from(super_block.sb_blocksize);
 
@@ -156,7 +156,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrBtree {
             super_block,
             hash,
             leaf_offset,
-            |block, reader| self.btree.map_block(reader.by_ref(), &super_block, block),
+            |block, reader| self.btree.map_block(reader.by_ref(), super_block, block),
         )
     }
 }

--- a/src/libxfuse/attr_leaf.rs
+++ b/src/libxfuse/attr_leaf.rs
@@ -103,7 +103,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrLeaf {
 
     fn list(&mut self, buf_reader: &mut R, super_block: &Sb) -> Vec<u8> {
         let mut list: Vec<u8> =
-            Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), &super_block) as usize);
+            Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), super_block) as usize);
 
         self.leaf
             .list(buf_reader.by_ref(), &mut list, self.leaf_offset);

--- a/src/libxfuse/attr_node.rs
+++ b/src/libxfuse/attr_node.rs
@@ -164,7 +164,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrNode {
 
             let blk = self
                 .node
-                .first_block(buf_reader.by_ref(), &super_block, |block, _| {
+                .first_block(buf_reader.by_ref(), super_block, |block, _| {
                     self.map_logical_block_to_fs_block(block.into())
                 });
             let leaf_offset = blk * u64::from(super_block.sb_blocksize);
@@ -189,7 +189,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrNode {
         let hash = hashname(name);
 
         let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
-        let blk = node.lookup(buf_reader.by_ref(), &super_block, hash, |block, _| {
+        let blk = node.lookup(buf_reader.by_ref(), super_block, hash, |block, _| {
             self.map_logical_block_to_fs_block(block.into())
         });
         let leaf_offset = blk * u64::from(super_block.sb_blocksize);
@@ -202,11 +202,11 @@ impl<R: BufRead + Seek> Attr<R> for AttrNode {
 
     fn list(&mut self, buf_reader: &mut R, super_block: &Sb) -> Vec<u8> {
         let mut list: Vec<u8> =
-            Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), &super_block) as usize);
+            Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), super_block) as usize);
 
         let blk = self
             .node
-            .first_block(buf_reader.by_ref(), &super_block, |block, _| {
+            .first_block(buf_reader.by_ref(), super_block, |block, _| {
                 self.map_logical_block_to_fs_block(block.into())
             });
         let leaf_offset = blk * u64::from(super_block.sb_blocksize);
@@ -228,7 +228,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrNode {
         let hash = hashname(name);
 
         let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
-        let blk = node.lookup(buf_reader.by_ref(), &super_block, hash, |block, _| {
+        let blk = node.lookup(buf_reader.by_ref(), super_block, hash, |block, _| {
             self.map_logical_block_to_fs_block(block.into())
         });
         let leaf_offset = blk * u64::from(super_block.sb_blocksize);

--- a/src/libxfuse/attr_shortform.rs
+++ b/src/libxfuse/attr_shortform.rs
@@ -131,10 +131,10 @@ impl<R: BufRead + Seek> Attr<R> for AttrShortform {
 
     fn list(&mut self, buf_reader: &mut R, super_block: &Sb) -> Vec<u8> {
         let mut list: Vec<u8> =
-            Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), &super_block) as usize);
+            Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), super_block) as usize);
 
         for entry in self.list.iter() {
-            list.extend_from_slice(&get_namespace_from_flags(entry.flags).as_bytes().to_vec());
+            list.extend_from_slice(get_namespace_from_flags(entry.flags).as_bytes());
             let namelen = entry.namelen as usize;
             list.extend_from_slice(&entry.nameval[0..namelen].to_vec());
             list.push(0)

--- a/src/libxfuse/da_btree.rs
+++ b/src/libxfuse/da_btree.rs
@@ -223,7 +223,7 @@ impl XfsDa3Intnode {
             let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
             node.lookup(
                 buf_reader.by_ref(),
-                &super_block,
+                super_block,
                 hash,
                 map_da_block_to_fs_block,
             )
@@ -246,7 +246,7 @@ impl XfsDa3Intnode {
                 .unwrap();
 
             let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
-            node.first_block(buf_reader.by_ref(), &super_block, map_da_block_to_fs_block)
+            node.first_block(buf_reader.by_ref(), super_block, map_da_block_to_fs_block)
         }
     }
 }

--- a/src/libxfuse/dir3_node.rs
+++ b/src/libxfuse/dir3_node.rs
@@ -160,7 +160,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Node {
 
         if magic.unwrap() == XFS_DA3_NODE_MAGIC {
             let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
-            let blk = node.lookup(buf_reader.by_ref(), &super_block, hash, |block, _| {
+            let blk = node.lookup(buf_reader.by_ref(), super_block, hash, |block, _| {
                 self.map_dblock_number(block.into())
             });
 
@@ -235,13 +235,11 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Node {
         };
 
         let mut bmbt_rec = self.map_dblock(idx);
-        let mut bmbt_rec_idx;
-
-        if let Some(bmbt_rec_some) = &bmbt_rec {
-            bmbt_rec_idx = idx - bmbt_rec_some.br_startoff;
+        let mut bmbt_rec_idx = if let Some(bmbt_rec_some) = &bmbt_rec {
+            idx - bmbt_rec_some.br_startoff
         } else {
-            return Err(ENOENT);
-        }
+            return Err(ENOENT)
+        };
 
         while let Some(bmbt_rec_some) = &bmbt_rec {
             while bmbt_rec_idx < bmbt_rec_some.br_blockcount {

--- a/src/libxfuse/file_btree.rs
+++ b/src/libxfuse/file_btree.rs
@@ -55,7 +55,7 @@ impl<R: BufRead + Seek> File<R> for FileBtree {
         while remaining_size > 0 {
             let blk = self
                 .btree
-                .map_block(buf_reader.by_ref(), &super_block, logical_block as u64);
+                .map_block(buf_reader.by_ref(), super_block, logical_block as u64);
             buf_reader
                 .seek(SeekFrom::Start(blk * u64::from(self.block_size)))
                 .unwrap();

--- a/src/libxfuse/volume.rs
+++ b/src/libxfuse/volume.rs
@@ -323,7 +323,7 @@ impl Filesystem for Volume {
         let attrs = dinode.get_attrs(buf_reader.by_ref(), &self.sb);
         match attrs {
             Some(attrs) => {
-                let attrs_size = attrs.get_size(buf_reader.by_ref(), &self.sb, &name);
+                let attrs_size = attrs.get_size(buf_reader.by_ref(), &self.sb, name);
 
                 if size == 0 {
                     reply.size(attrs_size);
@@ -335,7 +335,7 @@ impl Filesystem for Volume {
                     return;
                 }
 
-                reply.data(attrs.get(buf_reader.by_ref(), &self.sb, &name).as_slice());
+                reply.data(attrs.get(buf_reader.by_ref(), &self.sb, name).as_slice());
             }
             None => {
                 if size == 0 {


### PR DESCRIPTION
* Remove workaround for rustup bug 2774.  It's fixed upstream.
* FreeBSD 11.4 is EoL.  Switch CI to 12.3, the oldest supported release.
* Make use of enum namespacing
* Minor clippy cleanup