### PR TITLE
Clippy cleanup

### DIFF
--- a/src/libxfuse/attr.rs
+++ b/src/libxfuse/attr.rs
@@ -449,7 +449,7 @@ impl AttrRmtHdr {
             .seek(SeekFrom::Start(start_offset + u64::from(rm_offset)))
             .unwrap();
 
-        let mut data = Vec::<u8>::with_capacity(rm_bytes as usize);
+        let mut data = vec![0; rm_bytes as usize];
         buf_reader.read_exact(&mut data).unwrap();
 
         (

--- a/src/libxfuse/dir3.rs
+++ b/src/libxfuse/dir3.rs
@@ -218,7 +218,7 @@ impl Dir2Data {
         start_block: u64,
     ) -> Dir2Data {
         let offset = start_block * (superblock.sb_blocksize as u64);
-        buf_reader.seek(SeekFrom::Start(offset as u64)).unwrap();
+        buf_reader.seek(SeekFrom::Start(offset)).unwrap();
 
         let hdr = Dir3DataHdr::from(buf_reader.by_ref());
 

--- a/src/libxfuse/dir3_block.rs
+++ b/src/libxfuse/dir3_block.rs
@@ -30,6 +30,7 @@ use std::io::{BufRead, Seek, SeekFrom};
 use std::mem;
 use std::time::{Duration, UNIX_EPOCH};
 
+use super::S_IFMT;
 use super::da_btree::hashname;
 use super::definitions::*;
 use super::dinode::Dinode;
@@ -41,7 +42,7 @@ use super::utils::{get_file_type, FileKind};
 
 use byteorder::{BigEndian, ReadBytesExt};
 use fuser::{FileAttr, FileType};
-use libc::{c_int, ENOENT, S_IFMT};
+use libc::{c_int, ENOENT};
 
 pub const XFS_DIR2_DATA_FD_COUNT: usize = 3;
 
@@ -175,7 +176,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Block {
                 ),
                 crtime: UNIX_EPOCH,
                 kind,
-                perm: dinode.di_core.di_mode & (!(S_IFMT as u16)),
+                perm: dinode.di_core.di_mode & !S_IFMT,
                 nlink: dinode.di_core.di_nlink,
                 uid: dinode.di_core.di_uid,
                 gid: dinode.di_core.di_gid,

--- a/src/libxfuse/dir3_bptree.rs
+++ b/src/libxfuse/dir3_bptree.rs
@@ -30,6 +30,7 @@ use std::io::{BufRead, Seek, SeekFrom};
 use std::mem;
 use std::time::{Duration, UNIX_EPOCH};
 
+use super::S_IFMT;
 use super::bmbt_rec::BmbtRec;
 use super::btree::{BmbtKey, BmdrBlock, XfsBmbtBlock, XfsBmbtPtr};
 use super::da_btree::{hashname, XfsDa3NodeEntry, XfsDa3NodeHdr};
@@ -41,7 +42,7 @@ use super::utils::{get_file_type, FileKind};
 
 use byteorder::{BigEndian, ReadBytesExt};
 use fuser::{FileAttr, FileType};
-use libc::{c_int, ENOENT, S_IFMT};
+use libc::{c_int, ENOENT};
 
 #[derive(Debug)]
 pub struct Dir2Btree {
@@ -282,7 +283,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Btree {
                         ),
                         crtime: UNIX_EPOCH,
                         kind,
-                        perm: dinode.di_core.di_mode & (!(S_IFMT as u16)),
+                        perm: dinode.di_core.di_mode & !S_IFMT,
                         nlink: dinode.di_core.di_nlink,
                         uid: dinode.di_core.di_uid,
                         gid: dinode.di_core.di_gid,

--- a/src/libxfuse/dir3_leaf.rs
+++ b/src/libxfuse/dir3_leaf.rs
@@ -155,7 +155,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Leaf {
         let mut entry: &Dir2Data = &self.entries[idx];
 
         buf_reader
-            .seek(SeekFrom::Start(entry.offset + (offset as u64)))
+            .seek(SeekFrom::Start(entry.offset + offset))
             .unwrap();
 
         loop {

--- a/src/libxfuse/dir3_leaf.rs
+++ b/src/libxfuse/dir3_leaf.rs
@@ -29,6 +29,7 @@ use std::io::{BufRead, Seek, SeekFrom};
 use std::mem;
 use std::time::{Duration, UNIX_EPOCH};
 
+use super::S_IFMT;
 use super::bmbt_rec::BmbtRec;
 use super::da_btree::hashname;
 use super::definitions::*;
@@ -39,7 +40,7 @@ use super::utils::{get_file_type, FileKind};
 
 use byteorder::{BigEndian, ReadBytesExt};
 use fuser::{FileAttr, FileType};
-use libc::{c_int, ENOENT, S_IFMT};
+use libc::{c_int, ENOENT};
 
 #[derive(Debug)]
 pub struct Dir2Leaf {
@@ -119,7 +120,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Leaf {
             ),
             crtime: UNIX_EPOCH,
             kind,
-            perm: dinode.di_core.di_mode & (!(S_IFMT as u16)),
+            perm: dinode.di_core.di_mode & !S_IFMT,
             nlink: dinode.di_core.di_nlink,
             uid: dinode.di_core.di_uid,
             gid: dinode.di_core.di_gid,

--- a/src/libxfuse/dir3_node.rs
+++ b/src/libxfuse/dir3_node.rs
@@ -29,6 +29,7 @@ use std::io::{BufRead, Seek, SeekFrom};
 use std::mem;
 use std::time::{Duration, UNIX_EPOCH};
 
+use super::S_IFMT;
 use super::bmbt_rec::BmbtRec;
 use super::da_btree::{hashname, XfsDa3Intnode};
 use super::definitions::*;
@@ -39,7 +40,7 @@ use super::utils::{get_file_type, FileKind};
 
 use byteorder::{BigEndian, ReadBytesExt};
 use fuser::{FileAttr, FileType};
-use libc::{c_int, ENOENT, S_IFMT};
+use libc::{c_int, ENOENT};
 
 #[derive(Debug)]
 pub struct Dir3FreeHdr {
@@ -206,7 +207,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Node {
             ),
             crtime: UNIX_EPOCH,
             kind,
-            perm: dinode.di_core.di_mode & (!(S_IFMT as u16)),
+            perm: dinode.di_core.di_mode & !S_IFMT,
             nlink: dinode.di_core.di_nlink,
             uid: dinode.di_core.di_uid,
             gid: dinode.di_core.di_gid,

--- a/src/libxfuse/dir3_sf.rs
+++ b/src/libxfuse/dir3_sf.rs
@@ -28,6 +28,7 @@
 use std::io::{BufRead, Seek};
 use std::time::{Duration, UNIX_EPOCH};
 
+use super::S_IFMT;
 use super::{
     definitions::*,
     dinode::Dinode,
@@ -38,7 +39,7 @@ use super::{
 
 use byteorder::{BigEndian, ReadBytesExt};
 use fuser::{FileAttr, FileType};
-use libc::{c_int, ENOENT, S_IFMT};
+use libc::{c_int, ENOENT};
 
 // pub type XfsDir2SfOff = [u8; 2];
 
@@ -172,7 +173,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Sf {
                 ),
                 crtime: UNIX_EPOCH,
                 kind,
-                perm: dinode.di_core.di_mode & (!(S_IFMT as u16)),
+                perm: dinode.di_core.di_mode & !S_IFMT,
                 nlink: dinode.di_core.di_nlink,
                 uid: dinode.di_core.di_uid,
                 gid: dinode.di_core.di_gid,

--- a/src/libxfuse/mod.rs
+++ b/src/libxfuse/mod.rs
@@ -50,3 +50,6 @@ pub mod sb;
 pub mod symlink_extent;
 pub mod utils;
 pub mod volume;
+
+#[allow(clippy::unnecessary_cast)]  // It isn't unnecessary on all platforms.
+const S_IFMT: u16 = libc::S_IFMT as u16;

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,5 +82,5 @@ fn main() {
 
     let vol = Volume::from(&device);
 
-    mount2(vol, &mountpoint, &opts[..]).unwrap();
+    mount2(vol, mountpoint, &opts[..]).unwrap();
 }


### PR DESCRIPTION
* Fix a 0-byte read in AttrRmtHdr::from.  This solution _looks_ correct, but I don't yet have any way to test it.
* clippy::unnecessary_cast warnings
* clippy::needless_borrow
* clippy::suspicious_to_owned .  This was an actual performance bug. The to_owned() was a data copy that we didn't need.

Fixes #12 