### PR TITLE
Instead of using printf, use the tracing crate for debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +76,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -165,6 +174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,10 +207,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.4.1"
+name = "matchers"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "memchr"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f478948fd84d9f8e86967bf432640e46adfb5a4bd4f14ef7e864ab38220534ae"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-derive"
@@ -205,7 +239,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -230,6 +264,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "page_size"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +278,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pkg-config"
@@ -254,7 +300,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.89",
  "version_check",
 ]
 
@@ -280,12 +326,56 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.16"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.3.7",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustix"
@@ -315,6 +405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +437,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,7 +455,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.89",
  "unicode-xid",
 ]
 
@@ -369,6 +479,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +566,12 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -500,6 +687,8 @@ dependencies = [
  "libc",
  "num-derive",
  "num-traits",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -520,6 +709,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.89",
  "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,14 @@ uuid = "0.8.2"
 num-traits = "0.2.14"
 num-derive = "0.3.3"
 crc = "2.0.0"
+tracing = "0.1.37"
 
 [dependencies.clap]
 version = "4"
 default-features = false
 features=  [ "cargo", "color", "derive", "std", "suggestions", "wrap_help" ,"usage"]
+
+[dependencies.tracing-subscriber]
+version = "0.3.17"
+default-features = false
+features = [ "ansi", "env-filter", "fmt", "tracing-log" ]

--- a/src/libxfuse/utils.rs
+++ b/src/libxfuse/utils.rs
@@ -30,6 +30,7 @@ use fuser::FileType;
 use super::dir3::{XFS_DIR3_FT_DIR, XFS_DIR3_FT_REG_FILE, XFS_DIR3_FT_SYMLINK};
 
 use libc::{c_int, mode_t, ENOENT, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG};
+use tracing::error;
 
 pub enum FileKind {
     Type(u8),
@@ -43,7 +44,7 @@ pub fn get_file_type(kind: FileKind) -> Result<FileType, c_int> {
             XFS_DIR3_FT_DIR => Ok(FileType::Directory),
             XFS_DIR3_FT_SYMLINK => Ok(FileType::Symlink),
             _ => {
-                println!("Unknown file type.");
+                error!("Unknown file type {:?}.", file_type);
                 Err(ENOENT)
             }
         },
@@ -52,7 +53,7 @@ pub fn get_file_type(kind: FileKind) -> Result<FileType, c_int> {
             S_IFDIR => Ok(FileType::Directory),
             S_IFLNK => Ok(FileType::Symlink),
             _ => {
-                println!("Unknown file type.");
+                error!("Unknown file type {:?}.", (file_mode as mode_t) & S_IFMT);
                 Err(ENOENT)
             }
         },

--- a/src/libxfuse/volume.rs
+++ b/src/libxfuse/volume.rs
@@ -78,8 +78,6 @@ impl Volume {
 
 impl Filesystem for Volume {
     fn lookup(&mut self, _req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
-        println!("lookup: {:?}", name);
-
         let mut buf_reader = BufReader::new(&self.device);
         let inode_number = if parent == FUSE_ROOT_ID {
             self.sb.sb_rootino
@@ -105,8 +103,6 @@ impl Filesystem for Volume {
     }
 
     fn getattr(&mut self, _req: &Request, ino: u64, reply: ReplyAttr) {
-        println!("getattr: {}", ino);
-
         let dinode = Dinode::from(
             BufReader::new(&self.device).by_ref(),
             &self.sb,
@@ -158,8 +154,6 @@ impl Filesystem for Volume {
     }
 
     fn readlink(&mut self, _req: &Request, ino: u64, reply: fuser::ReplyData) {
-        println!("readlink: {}", ino);
-
         let dinode = Dinode::from(
             BufReader::new(&self.device).by_ref(),
             &self.sb,
@@ -180,8 +174,6 @@ impl Filesystem for Volume {
     }
 
     fn open(&mut self, _req: &Request, ino: u64, _flags: i32, reply: ReplyOpen) {
-        println!("open: {}", ino);
-
         let dinode = Dinode::from(
             BufReader::new(&self.device).by_ref(),
             &self.sb,
@@ -208,8 +200,6 @@ impl Filesystem for Volume {
         _lock_owner: Option<u64>,
         reply: fuser::ReplyData,
     ) {
-        println!("read: {}", _ino);
-
         let dinode = &self.open_files[fh as usize];
         let mut buf_reader = BufReader::new(&self.device);
 
@@ -231,15 +221,12 @@ impl Filesystem for Volume {
         _flush: bool,
         reply: ReplyEmpty,
     ) {
-        println!("release: {}", _ino);
-
         self.open_files.remove(fh as usize);
 
         reply.ok();
     }
 
     fn opendir(&mut self, _req: &Request, _ino: u64, _flags: i32, reply: ReplyOpen) {
-        println!("opendir: {}", _ino);
         reply.opened(0, 0);
     }
 
@@ -251,8 +238,6 @@ impl Filesystem for Volume {
         offset: i64,
         mut reply: ReplyDirectory,
     ) {
-        println!("readdir: {}", ino);
-
         let mut buf_reader = BufReader::new(&self.device);
         let inode_number = if ino == FUSE_ROOT_ID {
             self.sb.sb_rootino
@@ -284,14 +269,10 @@ impl Filesystem for Volume {
     }
 
     fn releasedir(&mut self, _req: &Request, _ino: u64, _fh: u64, _flags: i32, reply: ReplyEmpty) {
-        println!("releasedir: {}", _ino);
-
         reply.ok();
     }
 
     fn statfs(&mut self, _req: &Request, _ino: u64, reply: ReplyStatfs) {
-        println!("statfs: {}", _ino);
-
         reply.statfs(
             self.sb.sb_dblocks,
             self.sb.sb_fdblocks,
@@ -305,8 +286,6 @@ impl Filesystem for Volume {
     }
 
     fn getxattr(&mut self, _req: &Request, ino: u64, name: &OsStr, size: u32, reply: ReplyXattr) {
-        println!("getxattr: {:?}", name);
-
         let name = name.to_string_lossy();
         let name: Vec<&str> = name.split('.').collect();
         let name = name[1];
@@ -347,8 +326,6 @@ impl Filesystem for Volume {
     }
 
     fn listxattr(&mut self, _req: &Request, ino: u64, size: u32, reply: ReplyXattr) {
-        println!("listxattr: {}", ino);
-
         let mut buf_reader = BufReader::new(&self.device);
         let inode_number = if ino == FUSE_ROOT_ID {
             self.sb.sb_rootino
@@ -385,8 +362,6 @@ impl Filesystem for Volume {
     }
 
     fn access(&mut self, _req: &Request, _ino: u64, _mask: i32, reply: ReplyEmpty) {
-        println!("access: {}", _ino);
-
         reply.ok();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use libxfuse::volume::Volume;
 
 use clap::{crate_version, Parser};
 use fuser::{mount2, MountOption};
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser, Clone, Debug)]
 #[clap(version = crate_version!())]
@@ -48,6 +49,11 @@ struct App {
 }
 
 fn main() {
+    tracing_subscriber::fmt()
+        .pretty()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
     let app = App::parse();
 
     let mut opts = vec![


### PR DESCRIPTION
Happily, fuser3 also uses tracing, so simply setting RUST_LOG=debug will trace every fuse API call.  There's no need for us to do it manually.