### PR TITLE
Eliminate the internal use of String

### DIFF
--- a/src/libxfuse/attr_bptree.rs
+++ b/src/libxfuse/attr_bptree.rs
@@ -27,6 +27,7 @@
  */
 use std::{
     convert::TryInto,
+    ffi::OsStr,
     io::{BufRead, Seek, SeekFrom},
 };
 
@@ -78,7 +79,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrBtree {
         self.total_size.try_into().unwrap()
     }
 
-    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &str) -> u32 {
+    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> u32 {
         let hash = hashname(name);
 
         let blk = self.btree.map_block(buf_reader.by_ref(), super_block, 0);
@@ -131,7 +132,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrBtree {
         list
     }
 
-    fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &str) -> Vec<u8> {
+    fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Vec<u8> {
         let hash = hashname(name);
 
         let blk = self.btree.map_block(buf_reader.by_ref(), super_block, 0);

--- a/src/libxfuse/attr_leaf.rs
+++ b/src/libxfuse/attr_leaf.rs
@@ -27,6 +27,7 @@
  */
 use std::{
     convert::TryInto,
+    ffi::OsStr,
     io::{BufRead, Seek, SeekFrom},
 };
 
@@ -94,7 +95,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrLeaf {
         }
     }
 
-    fn get_size(&self, buf_reader: &mut R, _super_block: &Sb, name: &str) -> u32 {
+    fn get_size(&self, buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> u32 {
         let hash = hashname(name);
 
         self.leaf
@@ -111,7 +112,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrLeaf {
         list
     }
 
-    fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &str) -> Vec<u8> {
+    fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Vec<u8> {
         let hash = hashname(name);
 
         self.leaf.get(

--- a/src/libxfuse/attr_node.rs
+++ b/src/libxfuse/attr_node.rs
@@ -27,6 +27,7 @@
  */
 use std::{
     convert::TryInto,
+    ffi::OsStr,
     io::{BufRead, Seek, SeekFrom},
 };
 
@@ -185,7 +186,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrNode {
         self.total_size.try_into().unwrap()
     }
 
-    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &str) -> u32 {
+    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> u32 {
         let hash = hashname(name);
 
         let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
@@ -224,7 +225,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrNode {
         list
     }
 
-    fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &str) -> Vec<u8> {
+    fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Vec<u8> {
         let hash = hashname(name);
 
         let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);

--- a/src/libxfuse/attr_shortform.rs
+++ b/src/libxfuse/attr_shortform.rs
@@ -25,7 +25,9 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+use std::ffi::OsStr;
 use std::io::{BufRead, Seek};
+use std::os::unix::ffi::OsStrExt;
 
 use super::{
     attr::{get_namespace_from_flags, get_namespace_size_from_flags, Attr},
@@ -117,7 +119,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrShortform {
         self.total_size
     }
 
-    fn get_size(&self, _buf_reader: &mut R, _super_block: &Sb, name: &str) -> u32 {
+    fn get_size(&self, _buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> u32 {
         for entry in &self.list {
             let entry_name = entry.nameval[0..(entry.namelen as usize)].to_vec();
 
@@ -134,7 +136,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrShortform {
             Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), super_block) as usize);
 
         for entry in self.list.iter() {
-            list.extend_from_slice(get_namespace_from_flags(entry.flags).as_bytes());
+            list.extend_from_slice(get_namespace_from_flags(entry.flags));
             let namelen = entry.namelen as usize;
             list.extend_from_slice(&entry.nameval[0..namelen]);
             list.push(0)
@@ -143,7 +145,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrShortform {
         list
     }
 
-    fn get(&self, _buf_reader: &mut R, _super_block: &Sb, name: &str) -> Vec<u8> {
+    fn get(&self, _buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> Vec<u8> {
         for entry in &self.list {
             let entry_name = entry.nameval[0..(entry.namelen as usize)].to_vec();
 

--- a/src/libxfuse/da_btree.rs
+++ b/src/libxfuse/da_btree.rs
@@ -27,7 +27,9 @@
  */
 use std::{
     cmp::Ordering,
+    ffi::OsStr,
     io::{BufRead, Seek, SeekFrom},
+    os::unix::ffi::OsStrExt
 };
 
 use super::{definitions::*, sb::Sb};
@@ -41,7 +43,7 @@ macro_rules! rol32 {
     };
 }
 
-pub fn hashname(name: &str) -> XfsDahash {
+pub fn hashname(name: &OsStr) -> XfsDahash {
     let name = name.as_bytes();
     let mut namelen = name.len();
     let mut hash: XfsDahash = 0;

--- a/src/libxfuse/dir3_block.rs
+++ b/src/libxfuse/dir3_block.rs
@@ -26,6 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, Seek, SeekFrom};
 use std::mem;
 use std::time::{Duration, UNIX_EPOCH};
@@ -143,7 +144,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Block {
         &self,
         buf_reader: &mut R,
         super_block: &Sb,
-        name: &str,
+        name: &OsStr,
     ) -> Result<(FileAttr, u64), c_int> {
         let hash = hashname(name);
         if let Some(address) = self.hashes.get(&hash) {
@@ -196,7 +197,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Block {
         buf_reader: &mut R,
         _super_block: &Sb,
         offset: i64,
-    ) -> Result<(XfsIno, i64, FileType, String), c_int> {
+    ) -> Result<(XfsIno, i64, FileType, OsString), c_int> {
         let mut next = offset == 0;
         let offset = if offset == 0 {
             mem::size_of::<Dir3DataHdr>() as i64

--- a/src/libxfuse/dir3_bptree.rs
+++ b/src/libxfuse/dir3_bptree.rs
@@ -25,6 +25,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+use std::ffi::{OsStr, OsString};
 use std::cmp::Ordering;
 use std::io::{BufRead, Seek, SeekFrom};
 use std::mem;
@@ -190,7 +191,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Btree {
         &self,
         buf_reader: &mut R,
         super_block: &Sb,
-        name: &str,
+        name: &OsStr,
     ) -> Result<(FileAttr, u64), c_int> {
         let idx = super_block.get_dir3_leaf_offset();
         let hash = hashname(name);
@@ -307,7 +308,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Btree {
         buf_reader: &mut R,
         super_block: &Sb,
         offset: i64,
-    ) -> Result<(XfsIno, i64, FileType, String), c_int> {
+    ) -> Result<(XfsIno, i64, FileType, OsString), c_int> {
         let offset = offset as u64;
         let idx = offset >> (64 - 48); // tags take 16-bits
         let offset = offset & ((1 << (64 - 48)) - 1);

--- a/src/libxfuse/dir3_leaf.rs
+++ b/src/libxfuse/dir3_leaf.rs
@@ -25,6 +25,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, Seek, SeekFrom};
 use std::mem;
 use std::time::{Duration, UNIX_EPOCH};
@@ -80,7 +81,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Leaf {
         &self,
         buf_reader: &mut R,
         super_block: &Sb,
-        name: &str,
+        name: &OsStr,
     ) -> Result<(FileAttr, u64), c_int> {
         let hash = hashname(name);
 
@@ -137,7 +138,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Leaf {
         buf_reader: &mut R,
         _super_block: &Sb,
         offset: i64,
-    ) -> Result<(XfsIno, i64, FileType, String), c_int> {
+    ) -> Result<(XfsIno, i64, FileType, OsString), c_int> {
         let offset = offset as u64;
         let mut idx: usize = (offset >> (64 - 8)) as usize; // In V5 Inodes can contain up to 21 Extents
         let offset = offset & ((1 << (64 - 8)) - 1);

--- a/src/libxfuse/dir3_node.rs
+++ b/src/libxfuse/dir3_node.rs
@@ -25,6 +25,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, Seek, SeekFrom};
 use std::mem;
 use std::time::{Duration, UNIX_EPOCH};
@@ -139,7 +140,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Node {
         &self,
         buf_reader: &mut R,
         super_block: &Sb,
-        name: &str,
+        name: &OsStr,
     ) -> Result<(FileAttr, u64), c_int> {
         let dblock = super_block.get_dir3_leaf_offset();
         let hash = hashname(name);
@@ -224,7 +225,7 @@ impl<R: BufRead + Seek> Dir3<R> for Dir2Node {
         buf_reader: &mut R,
         _super_block: &Sb,
         offset: i64,
-    ) -> Result<(XfsIno, i64, FileType, String), c_int> {
+    ) -> Result<(XfsIno, i64, FileType, OsString), c_int> {
         let offset = offset as u64;
         let idx = offset >> (64 - 48); // tags take 16-bits
         let offset = offset & ((1 << (64 - 48)) - 1);


### PR DESCRIPTION
The fuser3 API uses OsStr.  Using the same type internally eliminates many data copies.

Also, simplify get_namespace_from_flags

Just return a byte slice, because that's how it's used.  Also, make get_namespace_size_from_flags more robust.

Fixes #16