### PR TITLE
Rebuild the golden testing image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,53 +8,10 @@ A read-only XFS implementation using FUSE, written for GSoC 2021.
 
 ## Golden Image
 
-I haven't yet standardized a golden image because I'm making it as I go. Currently, I have five
-directories each with a different number of entries and, as such, each is of a different type.
-
-### Filesystem configuration
-
-The filesystem has the following properties:
-
-* 4KB block size
-* 16KB directory size
-
-To create such a filesystem use the following sh command:
-
-```
-mkfs.xfs -n size=16384 -f <device>
-```
-
-### Directory tree
-
-The directory tree is as follows:
-
-| Name  | Number of entries |
-|:-----:|------------------:|
-| sf    |                 4 |
-| block |                 8 |
-| leaf  |               256 |
-| node  |              2048 |
-| btree |            204800 |
-
-### Entry naming convention
-
-Entries are named as follows:
-
-```
-frame<zero padded and right aligned 6-digit number starting from 0>.tst
-```
-
-### Entries
-
-All entries are directories, because they are the only supported format as of now.
-It's tedious to create such a large number of entries manually, you can use the following command:
-
-```
-for i in $(seq -f "%06g" 0 <number of entries - 1>)
-do
-    mkdir "frame$i"
-done
-```
+A canned golden image is checked into the repository, at
+`resources/xfs.img.zstd`.  It contains five subdirectories each using a
+different on-disk implementation, with a different number of empty files inside
+of each.  Run `scripts/mkimg.sh` to rebuild it.
 
 ## License
 

--- a/scripts/mkimg.sh
+++ b/scripts/mkimg.sh
@@ -8,21 +8,21 @@ mkfiles() {
 
 	mkdir $DIR
 	for i in $(seq -f "%06g" 0 $(( COUNT - 1 )) ); do
-		mkdir "$DIR/frame${i}"
+		touch "$DIR/frame${i}"
 	done
 }
 
-truncate -s 512m resources/xfs.img
-mkfs.xfs -n size=16384 -f resources/xfs.img
+truncate -s 32m resources/xfs.img
+mkfs.xfs -n size=8192 -f resources/xfs.img
 MNTDIR=`mktemp -d`
 mount -t xfs resources/xfs.img $MNTDIR
-mkfiles ${MNTDIR}/sf 4
-mkfiles ${MNTDIR}/block 8
+mkfiles ${MNTDIR}/sf 2
+mkfiles ${MNTDIR}/block 32
 mkfiles ${MNTDIR}/leaf 256
-mkfiles ${MNTDIR}/node 2048
-mkfiles ${MNTDIR}/btree 204800
+mkfiles ${MNTDIR}/node 1024
+mkfiles ${MNTDIR}/btree 8192
 umount ${MNTDIR}
 
 rmdir $MNTDIR
 
-zstd resources/xfs.img
+zstd -f resources/xfs.img

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -52,11 +52,11 @@ lazy_static! {
 // This is a function of the golden image creation.
 fn ents_per_dir(d: &str) -> usize {
     match d {
-        "sf" => 4,
-        "block" => 8,
+        "sf" => 2,
+        "block" => 32,
         "leaf" => 256,
-        "node" => 2048,
-        "btree" => 204800,
+        "node" => 1024,
+        "btree" => 8192,
         _ => 0
     }
 }
@@ -165,9 +165,9 @@ impl Drop for Harness {
 
 #[template]
 #[rstest]
-#[case::leaf("leaf")]
 #[case::sf("sf")]
 #[case::block("block")]
+#[case::leaf("leaf")]
 #[case::node("node")]
 #[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/22" ]
 #[case::btree("btree")]
@@ -200,11 +200,11 @@ fn lookup(harness: Harness, #[case] d: &str) {
 #[named]
 #[rstest]
 #[case::sf("sf")]
+#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/25" ]
 #[case::block("block")]
+#[case::leaf("leaf")]
 #[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/25" ]
 #[case::node("node")]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/25" ]
-#[case::leaf("leaf")]
 #[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/22" ]
 #[case::btree("btree")]
 fn readdir(harness: Harness, #[case] d: &str) {
@@ -216,10 +216,9 @@ fn readdir(harness: Harness, #[case] d: &str) {
     let mut count = 0;
     for (i, rent) in ents.enumerate() {
         let ent = rent.unwrap();
-        dbg!(&ent);
         let expected_name = format!("frame{:06}", i);
         assert_eq!(ent.file_name(), OsStr::new(&expected_name));
-        assert!(ent.file_type().unwrap().is_dir());
+        assert!(ent.file_type().unwrap().is_file());
         let md = ent.metadata().unwrap();
         assert_eq!(ent.ino(), md.ino());
         // The other metadata fields are checked in a separate test case.


### PR DESCRIPTION
* Make it much smaller.
* Use regular files instead of directories, further reducing space consumption.
* Ensure that each subdirectory uses the implementation that it's supposed to.  Previously, the "block" directory was actually a shortform, and the "leaf" was actually a block.