### PR TITLE
Fix readdir in Block directories

### DIFF
--- a/src/libxfuse/dir3.rs
+++ b/src/libxfuse/dir3.rs
@@ -167,9 +167,9 @@ impl Dir2DataEntry {
     pub fn get_length<T: BufRead + Seek>(buf_reader: &mut T) -> i64 {
         buf_reader.seek(SeekFrom::Current(8)).unwrap();
         let namelen = buf_reader.read_u8().unwrap();
-        buf_reader.seek(SeekFrom::Current(-8)).unwrap();
+        buf_reader.seek(SeekFrom::Current(-9)).unwrap();
 
-        ((((namelen as i64) + 1 + 2) + 8 - 1) / 8) * 8
+        ((((namelen as i64) + 8 + 1 + 2) + 8 - 1) / 8) * 8
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -200,7 +200,6 @@ fn lookup(harness: Harness, #[case] d: &str) {
 #[named]
 #[rstest]
 #[case::sf("sf")]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/25" ]
 #[case::block("block")]
 #[case::leaf("leaf")]
 #[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/25" ]


### PR DESCRIPTION
The calculation in Dir2DataEntry::get_length() was incorrect, and it altered the directory's seek position as an unintended side effect.

Partially fixes #25