### PR TITLE
Fix readdir in node directories

### DIFF
--- a/src/libxfuse/dir3.rs
+++ b/src/libxfuse/dir3.rs
@@ -66,6 +66,8 @@ pub struct Dir3BlkHdr {
 }
 
 impl Dir3BlkHdr {
+    pub const SIZE: u64 = 48;
+
     pub fn from<T: BufRead>(buf_reader: &mut T) -> Dir3BlkHdr {
         let magic = buf_reader.read_u32::<BigEndian>().unwrap();
         let crc = buf_reader.read_u32::<BigEndian>().unwrap();
@@ -92,6 +94,8 @@ pub struct Dir2DataFree {
 }
 
 impl Dir2DataFree {
+    pub const SIZE: u64 = 4;
+
     pub fn from<T: BufRead>(buf_reader: &mut T) -> Dir2DataFree {
         let offset = buf_reader.read_u16::<BigEndian>().unwrap();
         let length = buf_reader.read_u16::<BigEndian>().unwrap();
@@ -108,6 +112,8 @@ pub struct Dir3DataHdr {
 }
 
 impl Dir3DataHdr {
+    pub const SIZE: u64 = Dir3BlkHdr::SIZE + XFS_DIR2_DATA_FD_COUNT as u64 * Dir2DataFree::SIZE + 4;
+
     pub fn from<T: BufRead>(buf_reader: &mut T) -> Dir3DataHdr {
         let hdr = Dir3BlkHdr::from(buf_reader.by_ref());
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -202,7 +202,6 @@ fn lookup(harness: Harness, #[case] d: &str) {
 #[case::sf("sf")]
 #[case::block("block")]
 #[case::leaf("leaf")]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/25" ]
 #[case::node("node")]
 #[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/22" ]
 #[case::btree("btree")]


### PR DESCRIPTION
Completely rewrite the logic in <Dir2Node as Dir3>::next().  The old logic was confusing, and did not check the directory block size.  I think there were other logic errors, too.

Partially fixes #25