### PR TITLE
Fix reading the pointers in a BTree Dir

### DIFF
--- a/src/libxfuse/btree.rs
+++ b/src/libxfuse/btree.rs
@@ -102,6 +102,8 @@ pub struct BmdrBlock {
 }
 
 impl BmdrBlock {
+    pub const SIZE: usize = 4;
+
     pub fn from<R: BufRead>(buf_reader: &mut R) -> BmdrBlock {
         let bb_level = buf_reader.read_u16::<BigEndian>().unwrap();
         let bb_numrecs = buf_reader.read_u16::<BigEndian>().unwrap();
@@ -119,6 +121,8 @@ pub struct BmbtKey {
 }
 
 impl BmbtKey {
+    pub const SIZE: usize = 8;
+
     pub fn from<R: BufRead>(buf_reader: &mut R) -> BmbtKey {
         let br_startoff = buf_reader.read_u64::<BigEndian>().unwrap();
 

--- a/src/libxfuse/dinode_core.rs
+++ b/src/libxfuse/dinode_core.rs
@@ -108,6 +108,8 @@ pub struct DinodeCore {
 }
 
 impl DinodeCore {
+    pub const SIZE: usize = 0xb0;   // For inode version 3
+
     pub fn from<R: BufRead>(buf_reader: &mut R) -> DinodeCore {
         let di_magic = buf_reader.read_u16::<BigEndian>().unwrap();
         if di_magic != XFS_DINODE_MAGIC {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -169,7 +169,7 @@ impl Drop for Harness {
 #[case::block("block")]
 #[case::leaf("leaf")]
 #[case::node("node")]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/22" ]
+#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/30" ]
 #[case::btree("btree")]
 fn all_dir_types(d: &str) {}
 
@@ -203,7 +203,7 @@ fn lookup(harness: Harness, #[case] d: &str) {
 #[case::block("block")]
 #[case::leaf("leaf")]
 #[case::node("node")]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/22" ]
+#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/30" ]
 #[case::btree("btree")]
 fn readdir(harness: Harness, #[case] d: &str) {
     require_fusefs!();


### PR DESCRIPTION
There was an error in the file system format documentation.  The original implementation followed the docs, and thus did not read the pointers from the correct disk location.

This change will almost certainly need to be propagated to other locations, like for reading BTree-encoded regular files, but those have no test coverage yet.

Fixes #22