### PR TITLE
Add integration tests relating to hidden directory entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ function_name = "0.3.0"
 lazy_static = "1.4.0"
 rstest = "0.16.0"
 rstest_reuse = "0.6.0"
-nix = { version = "0.27.0", features = [ "fs", "user" ] }
+nix = { version = "0.27.0", features = [ "dir", "fs", "user" ] }
 sysctl = "0.5"
 tempfile = "3.0"
 walkdir = "2.0"


### PR DESCRIPTION
* Add integration tests to lookup "." and ".."
* Add tests for readdir returning hidden entries.
    Currently, they fail.
    
    Issue #38
    Issue #39