### PR TITLE
Make readdir show hidden entries in SF dirs

### DIFF
--- a/src/libxfuse/dinode.rs
+++ b/src/libxfuse/dinode.rs
@@ -138,7 +138,7 @@ impl Dinode {
             },
             S_IFDIR => match di_core.di_format {
                 XfsDinodeFmt::Local => {
-                    let dir_sf = Dir2Sf::from(buf_reader.by_ref());
+                    let dir_sf = Dir2Sf::from(buf_reader.by_ref(), inode_number);
                     di_u = Some(DiU::Dir2Sf(dir_sf));
                 }
                 XfsDinodeFmt::Extents => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -352,7 +352,7 @@ fn readdir(harness: Harness, #[case] d: &str) {
 // unconditionally hides the hidden entries.
 #[named]
 #[rstest]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/38" ]
+#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/39" ]
 #[case::sf("sf")]
 #[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/39" ]
 #[case::block("block")]


### PR DESCRIPTION
Alone out of all directory types, SF dirs do not store "." and ".." entries on disk.  So we must synthesize them.

Fixes #38