### PR TITLE
Make readdir return the correct inode number for the mountpoint

### DIFF
--- a/src/libxfuse/volume.rs
+++ b/src/libxfuse/volume.rs
@@ -254,6 +254,13 @@ impl Filesystem for Volume {
             let res = dir.next(BufReader::new(&self.device).by_ref(), &self.sb, off);
             match res {
                 Ok((ino, offset, kind, name)) => {
+                    // FUSE requires the file system's root directory to have a
+                    // fixed inode number.
+                    let ino = if ino == self.sb.sb_rootino {
+                        FUSE_ROOT_ID
+                    } else {
+                        ino
+                    };
                     let res = reply.add(ino, offset, kind, name);
                     if res {
                         reply.ok();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -352,15 +352,10 @@ fn readdir(harness: Harness, #[case] d: &str) {
 // unconditionally hides the hidden entries.
 #[named]
 #[rstest]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/39" ]
 #[case::sf("sf")]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/39" ]
 #[case::block("block")]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/39" ]
 #[case::leaf("leaf")]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/39" ]
 #[case::node("node")]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/39" ]
 #[case::btree("btree")]
 fn readdir_dots(harness: Harness, #[case] d: &str) {
     use nix::{dir::Dir, fcntl::OFlag, sys::stat::Mode};


### PR DESCRIPTION
FUSE requires the mountpoint to have an inode number of 1.

Fixes #39