### PR TITLE
Fix listing extended attributes from XFS_DINODE_FMT_EXTENTS

### DIFF
--- a/src/libxfuse/attr.rs
+++ b/src/libxfuse/attr.rs
@@ -43,7 +43,7 @@ use uuid::Uuid;
 
 use super::{
     da_btree::XfsDa3Blkinfo,
-    definitions::{XfsFileoff, XfsFsblock},
+    definitions::{XFS_ATTR3_LEAF_MAGIC, XfsFileoff, XfsFsblock},
     sb::Sb,
     utils::decode_from
 };
@@ -101,7 +101,8 @@ pub struct AttrLeafHdr {
 
 impl AttrLeafHdr {
     pub fn sanity(&self, super_block: &Sb) {
-        self.info.sanity(super_block)
+        self.info.sanity(super_block);
+        assert_eq!(self.info.magic, XFS_ATTR3_LEAF_MAGIC);
     }
 }
 
@@ -267,7 +268,7 @@ impl AttrLeafblock {
                 .seek(SeekFrom::Current(i64::from(entry.nameidx)))
                 .unwrap();
 
-            if entry.flags & XFS_ATTR_LOCAL == 0 {
+            if entry.flags & XFS_ATTR_LOCAL != 0 {
                 let name_entry = AttrLeafNameLocal::from(buf_reader.by_ref());
 
                 list.extend_from_slice(get_namespace_from_flags(entry.flags));

--- a/src/libxfuse/attr_bptree.rs
+++ b/src/libxfuse/attr_bptree.rs
@@ -31,6 +31,8 @@ use std::{
     io::{BufRead, Seek, SeekFrom},
 };
 
+use bincode::de::read::Reader;
+
 use super::{
     attr::{Attr, AttrLeafblock},
     btree::Btree,
@@ -45,7 +47,7 @@ pub struct AttrBtree {
     pub total_size: i64,
 }
 
-impl<R: BufRead + Seek> Attr<R> for AttrBtree {
+impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
     fn get_total_size(&mut self, buf_reader: &mut R, super_block: &Sb) -> u32 {
         if self.total_size == -1 {
             let mut total_size: u32 = 0;

--- a/src/libxfuse/attr_leaf.rs
+++ b/src/libxfuse/attr_leaf.rs
@@ -39,6 +39,7 @@ use super::{
     da_btree::hashname,
     definitions::{XfsFileoff, XfsFsblock},
     sb::Sb,
+    utils::decode_from
 };
 
 
@@ -61,7 +62,8 @@ impl AttrLeaf {
             let leaf_offset = rec.br_startblock * u64::from(superblock.sb_blocksize);
             buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
-            let leaf = AttrLeafblock::from(buf_reader.by_ref(), superblock);
+            let leaf: AttrLeafblock = decode_from(buf_reader.by_ref()).unwrap();
+            leaf.sanity(superblock);
 
             AttrLeaf {
                 bmx,

--- a/src/libxfuse/attr_leaf.rs
+++ b/src/libxfuse/attr_leaf.rs
@@ -31,6 +31,8 @@ use std::{
     io::{BufRead, Seek, SeekFrom},
 };
 
+use bincode::de::read::Reader;
+
 use super::{
     attr::{Attr, AttrLeafblock},
     bmbt_rec::BmbtRec,
@@ -38,6 +40,7 @@ use super::{
     definitions::{XfsFileoff, XfsFsblock},
     sb::Sb,
 };
+
 
 #[derive(Debug)]
 pub struct AttrLeaf {
@@ -49,7 +52,7 @@ pub struct AttrLeaf {
 }
 
 impl AttrLeaf {
-    pub fn from<R: BufRead + Seek>(
+    pub fn from<R: Reader + BufRead + Seek>(
         buf_reader: &mut R,
         superblock: &Sb,
         bmx: Vec<BmbtRec>,

--- a/src/libxfuse/attr_node.rs
+++ b/src/libxfuse/attr_node.rs
@@ -31,6 +31,8 @@ use std::{
     io::{BufRead, Seek, SeekFrom},
 };
 
+use bincode::de::read::Reader;
+
 use super::{
     attr::{Attr, AttrLeafblock},
     bmbt_rec::BmbtRec,
@@ -158,7 +160,7 @@ impl AttrNode {
     // }
 }
 
-impl<R: BufRead + Seek> Attr<R> for AttrNode {
+impl<R: Reader + BufRead + Seek> Attr<R> for AttrNode {
     fn get_total_size(&mut self, buf_reader: &mut R, super_block: &Sb) -> u32 {
         if self.total_size == -1 {
             let mut total_size: u32 = 0;

--- a/src/libxfuse/dinode.rs
+++ b/src/libxfuse/dinode.rs
@@ -329,7 +329,7 @@ impl Dinode {
         }
     }
 
-    pub fn get_attrs<R: BufRead + Seek>(
+    pub fn get_attrs<R: Reader + BufRead + Seek>(
         &self,
         buf_reader: &mut R,
         superblock: &Sb,

--- a/src/libxfuse/dinode.rs
+++ b/src/libxfuse/dinode.rs
@@ -54,8 +54,6 @@ use bincode::{
     Decode,
     de::{Decoder, read::Reader}
 };
-use byteorder::BigEndian;
-use byteorder::ReadBytesExt;
 use libc::{mode_t, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG};
 
 pub const LITERAL_AREA_OFFSET: u8 = 0xb0;
@@ -338,27 +336,12 @@ impl Dinode {
             Some(DiA::Attrsf(attr)) => Some(Box::new(attr.clone())),
             Some(DiA::Abmx(bmx)) => {
                 if self.di_core.di_anextents > 0 {
-                    buf_reader.seek(SeekFrom::Current(8)).unwrap();
-                    let magic = buf_reader.read_u16::<BigEndian>().unwrap();
-                    buf_reader.seek(SeekFrom::Current(-8)).unwrap();
-
-                    match magic {
-                        XFS_ATTR3_LEAF_MAGIC => {
-                            return Some(Box::new(AttrLeaf::from(
-                                buf_reader.by_ref(),
-                                superblock,
-                                bmx.clone(),
-                            )));
-                        }
-                        XFS_DA3_NODE_MAGIC => {
-                            return Some(Box::new(AttrLeaf::from(
-                                buf_reader.by_ref(),
-                                superblock,
-                                bmx.clone(),
-                            )));
-                        }
-                        _ => panic!("Unknown magic number!"),
-                    }
+                    // TODO: handle AttrNode, too.
+                    return Some(Box::new(AttrLeaf::from(
+                        buf_reader.by_ref(),
+                        superblock,
+                        bmx.clone(),
+                    )));
                 } else {
                     None
                 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -56,7 +56,7 @@ lazy_static! {
 fn attrs_per_file(f: &str) -> usize {
     match f {
         "local" => 4,
-        "extents" => 16,
+        "extents" => 64,
         _ => 0
     }
 }
@@ -358,15 +358,20 @@ fn lookup_dots(harness: Harness, #[case] d: &str) {
 }
 
 #[named]
-#[apply(all_xattr_fork_types)]
+#[rstest]
+#[case::local("local")]
+#[case::extents("extents")]
 fn lsextattr(harness: Harness, #[case] d: &str) {
     require_fusefs!();
 
     let p = harness.d.path().join("xattrs").join(d);
     let mut count = 0;
 
-    for (i, attrname) in xattr::list(p).unwrap().enumerate() {
+    let mut all_attrnames = xattr::list(p).unwrap().collect::<Vec<_>>();
+    all_attrnames.sort_unstable();
+    for (i, attrname) in all_attrnames.into_iter().enumerate() {
         let expected_name = OsString::from(format!("user.attr.{:06}", i));
+        //eprintln!("{:?}", attrname);
         assert_eq!(expected_name, attrname);
         count += 1;
     }


### PR DESCRIPTION
There were two bugs
* Dinode::get_attrs tried to read the attr's header's XfsDa3Blkinfo
  without seeking to the correct disk location first.
* AttrLeafblock::list inverted a logical check.
    
Fixes #45