### PR TITLE
extended attribute bug fixes

### DIFF
--- a/src/libxfuse/attr.rs
+++ b/src/libxfuse/attr.rs
@@ -189,7 +189,7 @@ impl AttrLeafblock {
                 .seek(SeekFrom::Current(i64::from(entry.nameidx)))
                 .unwrap();
 
-            if entry.flags & XFS_ATTR_LOCAL == 0 {
+            if entry.flags & XFS_ATTR_LOCAL != 0 {
                 let name_entry = AttrLeafNameLocal::from(buf_reader.by_ref());
                 total_size +=
                     get_namespace_size_from_flags(entry.flags) + u32::from(name_entry.namelen) + 1;
@@ -242,7 +242,7 @@ impl AttrLeafblock {
                         .seek(SeekFrom::Current(i64::from(entry.nameidx)))
                         .unwrap();
 
-                    if entry.flags & XFS_ATTR_LOCAL == 0 {
+                    if entry.flags & XFS_ATTR_LOCAL != 0 {
                         let name_entry = AttrLeafNameLocal::from(buf_reader.by_ref());
                         return name_entry.valuelen.into();
                     } else {

--- a/src/libxfuse/attr.rs
+++ b/src/libxfuse/attr.rs
@@ -327,7 +327,7 @@ impl AttrLeafblock {
                         .seek(SeekFrom::Current(i64::from(entry.nameidx)))
                         .unwrap();
 
-                    if entry.flags & XFS_ATTR_LOCAL == 0 {
+                    if entry.flags & XFS_ATTR_LOCAL != 0 {
                         let name_entry = AttrLeafNameLocal::from(buf_reader.by_ref());
 
                         let namelen = name_entry.namelen as usize;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -270,7 +270,6 @@ fn all_dir_types(d: &str) {}
 #[template]
 #[rstest]
 #[case::local("local")]
-#[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/45" ]
 #[case::extents("extents")]
 fn all_xattr_fork_types(d: &str) {}
 
@@ -358,9 +357,7 @@ fn lookup_dots(harness: Harness, #[case] d: &str) {
 }
 
 #[named]
-#[rstest]
-#[case::local("local")]
-#[case::extents("extents")]
+#[apply(all_xattr_fork_types)]
 fn lsextattr(harness: Harness, #[case] d: &str) {
     require_fusefs!();
 


### PR DESCRIPTION
* Fix listing extended attributes from XFS_DINODE_FMT_EXTENTS
* Fix getting the value of an xattr from XFS_DINODE_FMT_EXTENTS
* Fix size-only lsextattr and getextattr

Fixes #45