### PR TITLE
Fix mkimg.sh with newer versions of xfsprogs

### DIFF
--- a/scripts/mkimg.sh
+++ b/scripts/mkimg.sh
@@ -23,7 +23,7 @@ mkattrs() {
 }
 
 truncate -s 32m resources/xfs.img
-mkfs.xfs -n size=8192 -f resources/xfs.img
+mkfs.xfs --unsupported -n size=8192 -f resources/xfs.img
 MNTDIR=`mktemp -d`
 mount -t xfs resources/xfs.img $MNTDIR
 


### PR DESCRIPTION
Sometime between version 5.10.0 and 6.1.0 xfsprogs started refusing to create file systems less than 300 MB in size.  But there's an undocumented flag to allow it for test and debug purposes like ours.