### PR TITLE
Fix the statvfs response

### DIFF
--- a/src/libxfuse/volume.rs
+++ b/src/libxfuse/volume.rs
@@ -282,7 +282,7 @@ impl Filesystem for Volume {
 
     fn statfs(&mut self, _req: &Request, _ino: u64, reply: ReplyStatfs) {
         reply.statfs(
-            self.sb.sb_dblocks,
+            self.sb.sb_dblocks - u64::from(self.sb.sb_logblocks),
             self.sb.sb_fdblocks,
             self.sb.sb_fdblocks,
             self.sb.sb_icount,

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,8 @@ fn main() {
 
     let mut opts = vec![
         MountOption::FSName("fusefs".to_string()),
-        MountOption::Subtype("xfs".to_string())
+        MountOption::Subtype("xfs".to_string()),
+        MountOption::RO
     ];
     for o in app.options.iter() {
         opts.push(match o.as_str() {
@@ -70,8 +71,6 @@ fn main() {
             "nodev" => MountOption::NoDev,
             "suid" => MountOption::Suid,
             "nosuid" => MountOption::NoSuid,
-            "ro" => MountOption::RO,
-            "rw" => MountOption::RW,
             "exec" => MountOption::Exec,
             "noexec" => MountOption::NoExec,
             "atime" => MountOption::Atime,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -491,6 +491,20 @@ fn lsextattr_size(harness: Harness, #[case] d: &str) {
     }
 }
 
+mod pathconf {
+    use super::*;
+
+    #[named]
+    #[rstest]
+    fn name_max(harness: Harness) {
+        require_fusefs!();
+
+        let var = nix::unistd::PathconfVar::NAME_MAX;
+        let r = nix::unistd::pathconf(harness.d.path(), var).unwrap();
+        assert_eq!(Some(255), r);
+    }
+}
+
 /// List a directory's contents with readdir
 #[named]
 #[rstest]


### PR DESCRIPTION
* We are always read-only.  Read it as a mount option unconditionally.
* Fix the calculation for statvfs.f_blocks

Also, add tests for statfs and pathconf with _PC_NAME_MAX