### PR TITLE
Fix ENOATTR errors

### DIFF
--- a/src/libxfuse/attr.rs
+++ b/src/libxfuse/attr.rs
@@ -199,7 +199,7 @@ impl AttrLeafblock {
         buf_reader: &mut R,
         hash: u32,
         leaf_offset: u64,
-    ) -> u32 {
+    ) -> Result<u32, libc::c_int> {
         let mut low: u32 = 0;
         let mut high: u32 = self.hdr.count.into();
 
@@ -235,16 +235,16 @@ impl AttrLeafblock {
 
                     if entry.flags & XFS_ATTR_LOCAL != 0 {
                         let name_entry = AttrLeafNameLocal::from(buf_reader.by_ref());
-                        return name_entry.valuelen.into();
+                        return Ok(name_entry.valuelen.into());
                     } else {
                         let name_entry = AttrLeafNameRemote::from(buf_reader.by_ref());
-                        return name_entry.valuelen;
+                        return Ok(name_entry.valuelen);
                     }
                 }
             }
         }
 
-        panic!("Couldn't find the attribute entry");
+        Err(libc::ENOATTR)
     }
 
     pub fn list<R: BufRead + Seek>(
@@ -454,7 +454,7 @@ impl AttrRmtHdr {
 pub trait Attr<R: BufRead + Seek> {
     fn get_total_size(&mut self, buf_reader: &mut R, super_block: &Sb) -> u32;
 
-    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> u32;
+    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Result<u32, libc::c_int>;
 
     fn list(&mut self, buf_reader: &mut R, super_block: &Sb) -> Vec<u8>;
 

--- a/src/libxfuse/attr_bptree.rs
+++ b/src/libxfuse/attr_bptree.rs
@@ -81,7 +81,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
         self.total_size.try_into().unwrap()
     }
 
-    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> u32 {
+    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Result<u32, libc::c_int> {
         let hash = hashname(name);
 
         let blk = self.btree.map_block(buf_reader.by_ref(), super_block, 0);

--- a/src/libxfuse/attr_leaf.rs
+++ b/src/libxfuse/attr_leaf.rs
@@ -100,7 +100,7 @@ impl<R: BufRead + Seek> Attr<R> for AttrLeaf {
         }
     }
 
-    fn get_size(&self, buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> u32 {
+    fn get_size(&self, buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> Result<u32, libc::c_int> {
         let hash = hashname(name);
 
         self.leaf

--- a/src/libxfuse/attr_node.rs
+++ b/src/libxfuse/attr_node.rs
@@ -188,7 +188,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrNode {
         self.total_size.try_into().unwrap()
     }
 
-    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> u32 {
+    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Result<u32, libc::c_int> {
         let hash = hashname(name);
 
         let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);

--- a/src/libxfuse/attr_shortform.rs
+++ b/src/libxfuse/attr_shortform.rs
@@ -106,16 +106,16 @@ impl<R: BufRead + Seek> Attr<R> for AttrShortform {
         self.total_size
     }
 
-    fn get_size(&self, _buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> u32 {
+    fn get_size(&self, _buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> Result<u32, libc::c_int> {
         for entry in &self.list {
             let entry_name = entry.nameval[0..(entry.namelen as usize)].to_vec();
 
             if name.as_bytes().to_vec() == entry_name {
-                return entry.valuelen.into();
+                return Ok(entry.valuelen.into());
             }
         }
 
-        panic!("Couldn't find entry!");
+        Err(libc::ENOATTR)
     }
 
     fn list(&mut self, buf_reader: &mut R, super_block: &Sb) -> Vec<u8> {
@@ -143,6 +143,6 @@ impl<R: BufRead + Seek> Attr<R> for AttrShortform {
             }
         }
 
-        panic!("Couldn't find entry!");
+        unreachable!("Volume::getxattr should've already verified that the attribute exists");
     }
 }


### PR DESCRIPTION
When looking up an extended attribute that does not exist:

* We would panic, if the file contained other extended attributes
* We would return an empty string, if the file did not.

Instead, we should return ENOATTR in both cases.