### PR TITLE
Sanity check a block's magic before its UUID

### DIFF
--- a/src/libxfuse/attr.rs
+++ b/src/libxfuse/attr.rs
@@ -95,8 +95,8 @@ pub struct AttrLeafHdr {
 
 impl AttrLeafHdr {
     pub fn sanity(&self, super_block: &Sb) {
-        self.info.sanity(super_block);
         assert_eq!(self.info.magic, XFS_ATTR3_LEAF_MAGIC, "bad magic!  expected {:#x} but found {:#x}", XFS_ATTR3_LEAF_MAGIC, self.info.magic);
+        self.info.sanity(super_block);
     }
 }
 


### PR DESCRIPTION
Because a failed sanity check on the magic is more informative.