### PR TITLE
Fix a faulty hand-rolled binary search in da_btree.rs

### DIFF
--- a/scripts/mkimg.sh
+++ b/scripts/mkimg.sh
@@ -7,9 +7,7 @@ mkfiles() {
 	COUNT=$2
 
 	mkdir $DIR
-	for i in $(seq -f "%06g" 0 $(( COUNT - 1 )) ); do
-		touch "$DIR/frame${i}"
-	done
+	seq -f "%06g" 0 $(( COUNT - 1 )) | xargs -I % touch "$DIR/frame%"
 }
 
 # Make a directory filled with files that have very long file names
@@ -18,9 +16,7 @@ mkfiles2() {
 	COUNT=$2
 
 	mkdir $DIR
-	for i in $(seq -f "%08.0f" 0 $(( COUNT - 1 )) ); do
-		touch "$DIR/frame__________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________${i}"
-	done
+	seq -f "%08.0f" 0 $(( COUNT - 1 )) | xargs -I % touch "$DIR/frame__________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________%"
 }
 
 mkattrs() {
@@ -28,9 +24,8 @@ mkattrs() {
 	COUNT=$2
 
 	touch $FILE
-	for i in $(seq -f "%06g" 0 $(( COUNT - 1 )) ); do
-		setfattr -n user.attr.${i} -v value.${i} $FILE
-	done
+	seq -f "%06g" 0 $(( COUNT - 1 )) | xargs -I % \
+		setfattr -n user.attr.% -v value.% $FILE
 }
 
 fill_file() {

--- a/src/libxfuse/attr.rs
+++ b/src/libxfuse/attr.rs
@@ -465,7 +465,7 @@ pub trait Attr<R: BufRead + Seek> {
 
     fn list(&mut self, buf_reader: &mut R, super_block: &Sb) -> Vec<u8>;
 
-    fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Vec<u8>;
+    fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Result<Vec<u8>, libc::c_int>;
 }
 
 /// Open an attribute block, whose type may be unknown until its contents are examined.

--- a/src/libxfuse/attr_leaf.rs
+++ b/src/libxfuse/attr_leaf.rs
@@ -91,16 +91,16 @@ impl<R: BufRead + Seek> Attr<R> for AttrLeaf {
         list
     }
 
-    fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Vec<u8> {
+    fn get(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Result<Vec<u8>, i32> {
         let hash = hashname(name);
 
-        self.leaf.get(
+        Ok(self.leaf.get(
             buf_reader.by_ref(),
             super_block,
             hash,
             self.leaf_offset,
             |block, _| self.map_logical_block_to_actual_block(block),
-        )
+        ))
     }
 }
 

--- a/src/libxfuse/attr_shortform.rs
+++ b/src/libxfuse/attr_shortform.rs
@@ -132,14 +132,14 @@ impl<R: BufRead + Seek> Attr<R> for AttrShortform {
         list
     }
 
-    fn get(&self, _buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> Vec<u8> {
+    fn get(&self, _buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> Result<Vec<u8>, i32> {
         for entry in &self.list {
             let entry_name = entry.nameval[0..(entry.namelen as usize)].to_vec();
 
             if name.as_bytes().to_vec() == entry_name {
                 let namelen = entry.namelen as usize;
 
-                return entry.nameval[namelen..].to_vec();
+                return Ok(entry.nameval[namelen..].to_vec());
             }
         }
 

--- a/src/libxfuse/dir3_node.rs
+++ b/src/libxfuse/dir3_node.rs
@@ -125,7 +125,7 @@ impl<R: bincode::de::read::Reader + BufRead + Seek> Dir3<R> for Dir2Node {
             node.lookup(buf_reader.by_ref(), super_block, hash, |block, _| {
                 self.map_dblock_number(block.into())
             })
-        };
+        }?;
 
         let leaf_offset = blk * u64::from(super_block.sb_blocksize);
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();

--- a/src/libxfuse/volume.rs
+++ b/src/libxfuse/volume.rs
@@ -327,7 +327,10 @@ impl Filesystem for Volume {
                         } else if attrs_size > size {
                             reply.error(ERANGE);
                         } else {
-                            reply.data(attrs.get(buf_reader.by_ref(), &self.sb, name).as_slice());
+                            match attrs.get(buf_reader.by_ref(), &self.sb, name) {
+                                Ok(a) => reply.data(a.as_slice()),
+                                Err(e) => reply.error(e)
+                            }
                         }
                     }
                     Err(e) => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -817,7 +817,7 @@ fn readdir_1k(harness1k: Harness, #[case] d: &str) {
         // The other metadata fields are checked in a separate test case.
         count += 1;
     }
-    assert_eq!(count, ents_per_dir_4k(d));
+    assert_eq!(count, ents_per_dir_1k(d));
 }
 
 /// List a directory's contents with readdir

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -520,60 +520,86 @@ fn mount(harness4k: Harness) {
     drop(harness4k);
 }
 
-/// Lookup all entries in a directory
-//
-// In the 1k blocksize golden image, they use a different naming convention.
-#[named]
-#[apply(all_dir_types_1k)]
-fn lookup_1k(harness1k: Harness, #[case] d: &str) {
-    require_fusefs!();
+mod lookup {
+    use super::*;
 
-    let amode = AccessFlags::F_OK;
-    for i in 0..ents_per_dir_1k(d) {
-        let p = harness1k.d.path().join(format!("{d}/frame__________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________{i:08}"));
-        access(p.as_path(), amode)
-            .unwrap_or_else(|_| panic!("Lookup failed: {}", p.display()));
+    /// Lookup all entries in a directory
+    //
+    // In the 1k blocksize golden image, they use a different naming convention.
+    #[named]
+    #[apply(all_dir_types_1k)]
+    fn ok_1k(harness1k: Harness, #[case] d: &str) {
+        require_fusefs!();
+
+        let amode = AccessFlags::F_OK;
+        for i in 0..ents_per_dir_1k(d) {
+            let p = harness1k.d.path().join(format!("{d}/frame__________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________{i:08}"));
+            access(p.as_path(), amode)
+                .unwrap_or_else(|_| panic!("Lookup failed: {}", p.display()));
+        }
+    }
+
+    /// Lookup all entries in a directory
+    #[named]
+    #[apply(all_dir_types_4k)]
+    fn ok_4k(harness4k: Harness, #[case] d: &str) {
+        require_fusefs!();
+
+        let amode = AccessFlags::F_OK;
+        for i in 0..ents_per_dir_4k(d) {
+            let p = harness4k.d.path().join(format!("{d}/frame{i:06}"));
+            access(p.as_path(), amode)
+                .unwrap_or_else(|_| panic!("Lookup failed: {}", p.display()));
+        }
+    }
+
+    /// Lookup a directory's "." and ".." entries.  Verify their inode numbers
+    #[named]
+    #[rstest]
+    #[case::sf(harness4k, "sf")]
+    #[case::block(harness4k, "block")]
+    #[case::leaf(harness4k, "leaf")]
+    #[case::node(harness4k, "node")]
+    #[case::btree(harness4k, "btree")]
+    #[case::btree2_3(harness1k, "btree2.3")]
+    #[case::btree3(harness1k, "btree3")]
+    fn dots(#[case] h: fn() -> Harness, #[case] d: &str) {
+        require_fusefs!();
+
+        let harness = h();
+        let root_md = fs::metadata(harness.d.path()).unwrap();
+        let dir_md = fs::metadata(harness.d.path().join(d)).unwrap();
+        let dotpath = harness.d.path().join(format!("{d}/."));
+        let dot_md = fs::metadata(dotpath).unwrap();
+        assert_eq!(dir_md.ino(), dot_md.ino());
+
+        let dotdotpath = harness.d.path().join(format!("{d}/.."));
+        let dotdot_md = fs::metadata(dotdotpath).unwrap();
+        assert_eq!(root_md.ino(), dotdot_md.ino());
+    }
+
+    #[named]
+    #[rstest]
+    #[case::sf(harness4k, "sf")]
+    #[case::block(harness4k, "block")]
+    #[case::leaf(harness4k, "leaf")]
+    #[case::node(harness4k, "node")]
+    #[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/30" ]
+    #[case::btree(harness4k, "btree")]
+    #[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/74" ]
+    #[case::btree2_3(harness1k, "btree2.3")]
+    #[ignore = "https://github.com/KhaledEmaraDev/xfuse/issues/73" ]
+    #[case::btree3(harness1k, "btree3")]
+    fn enoent(#[case] h: fn() -> Harness, #[case] d: &str) {
+        require_fusefs!();
+
+        let harness = h();
+        let p = harness.d.path().join(format!("{d}/nonexistent"));
+        let e = access(p.as_path(), AccessFlags::F_OK).unwrap_err();
+        assert_eq!(e, nix::Error::ENOENT);
     }
 }
 
-/// Lookup all entries in a directory
-#[named]
-#[apply(all_dir_types_4k)]
-fn lookup_4k(harness4k: Harness, #[case] d: &str) {
-    require_fusefs!();
-
-    let amode = AccessFlags::F_OK;
-    for i in 0..ents_per_dir_4k(d) {
-        let p = harness4k.d.path().join(format!("{d}/frame{i:06}"));
-        access(p.as_path(), amode)
-            .unwrap_or_else(|_| panic!("Lookup failed: {}", p.display()));
-    }
-}
-
-/// Lookup a directory's "." and ".." entries.  Verify their inode numbers
-#[named]
-#[rstest]
-#[case::sf(harness4k, "sf")]
-#[case::block(harness4k, "block")]
-#[case::leaf(harness4k, "leaf")]
-#[case::node(harness4k, "node")]
-#[case::btree(harness4k, "btree")]
-#[case::btree2_3(harness1k, "btree2.3")]
-#[case::btree3(harness1k, "btree3")]
-fn lookup_dots(#[case] h: fn() -> Harness, #[case] d: &str) {
-    require_fusefs!();
-
-    let harness = h();
-    let root_md = fs::metadata(harness.d.path()).unwrap();
-    let dir_md = fs::metadata(harness.d.path().join(d)).unwrap();
-    let dotpath = harness.d.path().join(format!("{d}/."));
-    let dot_md = fs::metadata(dotpath).unwrap();
-    assert_eq!(dir_md.ino(), dot_md.ino());
-
-    let dotdotpath = harness.d.path().join(format!("{d}/.."));
-    let dotdot_md = fs::metadata(dotdotpath).unwrap();
-    assert_eq!(root_md.ino(), dotdot_md.ino());
-}
 
 mod lsextattr {
     use super::*;


### PR DESCRIPTION
XfsDa3Intnode::lookup contained a hand-written binary search algorithm
that would wrongly return 0 if the requested hash value was greater than
anything in the array.  This would still eventually return the desired
result (ENOENT or ENOATTR), but only after reading another level of
blocks from disk.
    
This commit replaces the faulty algorithm and enables
XfsDa3Intnode::lookup to return early.