### PR TITLE
Remove most sanity functions

### DIFF
--- a/src/libxfuse/attr_bptree.rs
+++ b/src/libxfuse/attr_bptree.rs
@@ -70,7 +70,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
 
             buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
-            let mut leaf = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+            let mut leaf = AttrLeafblock::from(buf_reader.by_ref());
             total_size += leaf.get_total_size(buf_reader.by_ref(), leaf_offset);
 
             while leaf.hdr.info.forw != 0 {
@@ -78,7 +78,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
                     leaf.hdr.info.forw.into()).unwrap();
                 let lfofs = lfblk * u64::from(super_block.sb_blocksize);
                 buf_reader.seek(SeekFrom::Start(lfofs)).unwrap();
-                leaf = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+                leaf = AttrLeafblock::from(buf_reader.by_ref());
                 total_size += leaf.get_total_size(buf_reader.by_ref(), lfofs);
             }
 
@@ -114,7 +114,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
         loop {
-            let leaf = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+            let leaf = AttrLeafblock::from(buf_reader.by_ref());
 
             match leaf.get_size(buf_reader.by_ref(), hash, leaf_offset) {
                 Ok(l) => return Ok(l),
@@ -148,7 +148,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
 
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
-        let mut leaf = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+        let mut leaf = AttrLeafblock::from(buf_reader.by_ref());
         leaf.list(buf_reader.by_ref(), &mut list, leaf_offset);
 
         while leaf.hdr.info.forw != 0 {
@@ -156,7 +156,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
                 leaf.hdr.info.forw.into()).unwrap();
             let lfofs = lfblk * u64::from(super_block.sb_blocksize);
             buf_reader.seek(SeekFrom::Start(lfofs)).unwrap();
-            leaf = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+            leaf = AttrLeafblock::from(buf_reader.by_ref());
             leaf.list(buf_reader.by_ref(), &mut list, lfofs);
         }
 
@@ -181,7 +181,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
 
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
-        let leaf = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+        let leaf = AttrLeafblock::from(buf_reader.by_ref());
 
         return Ok(leaf.get(
             buf_reader.by_ref(),

--- a/src/libxfuse/attr_node.rs
+++ b/src/libxfuse/attr_node.rs
@@ -150,14 +150,14 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrNode {
 
             buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
-            let mut node = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+            let mut node = AttrLeafblock::from(buf_reader.by_ref());
             total_size += node.get_total_size(buf_reader.by_ref(), leaf_offset);
 
             while node.hdr.info.forw != 0 {
                 let lfblk = self.map_logical_block_to_fs_block(node.hdr.info.forw.into());
                 let lfofs = lfblk * u64::from(super_block.sb_blocksize);
                 buf_reader.seek(SeekFrom::Start(lfofs)).unwrap();
-                node = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+                node = AttrLeafblock::from(buf_reader.by_ref());
                 total_size += node.get_total_size(buf_reader.by_ref(), lfofs);
             }
 
@@ -184,7 +184,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrNode {
 
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
         loop {
-            let leaf = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+            let leaf = AttrLeafblock::from(buf_reader.by_ref());
 
             match leaf.get_size(buf_reader.by_ref(), hash, leaf_offset) {
                 Ok(l) => return Ok(l),
@@ -212,14 +212,14 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrNode {
 
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
-        let mut leaf = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+        let mut leaf = AttrLeafblock::from(buf_reader.by_ref());
         leaf.list(buf_reader.by_ref(), &mut list, leaf_offset);
 
         while leaf.hdr.info.forw != 0 {
             let lfblk = self.map_logical_block_to_fs_block(leaf.hdr.info.forw.into());
             let lfofs = lfblk * u64::from(super_block.sb_blocksize);
             buf_reader.seek(SeekFrom::Start(lfofs)).unwrap();
-            leaf = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+            leaf = AttrLeafblock::from(buf_reader.by_ref());
             leaf.list(buf_reader.by_ref(), &mut list, lfofs);
         }
 
@@ -235,7 +235,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrNode {
         let leaf_offset = blk * u64::from(super_block.sb_blocksize);
 
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
-        let leaf = AttrLeafblock::from(buf_reader.by_ref(), super_block);
+        let leaf = AttrLeafblock::from(buf_reader.by_ref());
 
         Ok(leaf.get(
             buf_reader.by_ref(),

--- a/src/libxfuse/dir3_bptree.rs
+++ b/src/libxfuse/dir3_bptree.rs
@@ -92,7 +92,6 @@ impl<R: bincode::de::read::Reader + BufRead + Seek> Dir3<R> for Dir2Btree {
         'outer: loop {
             // We want to save the BTreeLeaf node's forw pointer here
             let leaf: Dir2LeafNDisk = decode_from(buf_reader.by_ref()).unwrap();
-            leaf.sanity(super_block);
 
             'inner: for lcr in 0.. {
                 let address = match leaf.get_address(hash, lcr) {

--- a/src/libxfuse/dir3_leaf.rs
+++ b/src/libxfuse/dir3_leaf.rs
@@ -68,7 +68,7 @@ impl Dir2Leaf {
         let offset = leaf_extent.br_startblock * (superblock.sb_blocksize as u64);
         let entry_size = superblock.sb_blocksize * (1 << superblock.sb_dirblklog);
 
-        let leaf = Dir2LeafDisk::from(buf_reader, superblock, offset, entry_size as usize);
+        let leaf = Dir2LeafDisk::from(buf_reader, offset, entry_size as usize);
         assert_eq!(leaf.hdr.info.magic, XFS_DIR3_LEAF1_MAGIC);
 
         Dir2Leaf {

--- a/src/libxfuse/dir3_node.rs
+++ b/src/libxfuse/dir3_node.rs
@@ -131,7 +131,6 @@ impl<R: bincode::de::read::Reader + BufRead + Seek> Dir3<R> for Dir2Node {
 
         'outer: loop {
             let leaf: Dir2LeafNDisk = decode_from(buf_reader.by_ref()).unwrap();
-            leaf.sanity(super_block);
 
             for lcr in 0.. {
                 let address = match leaf.get_address(hash, lcr) {


### PR DESCRIPTION
The only reason that sanity() existed was because it needs SuperBlock, and Decode::decode doesn't have access to that.  But since we now have a global SUPERBLOCK anyway, we may as well inline the sanity checking into the Decode impls.

But leave in DinodeCore::sanity, because that struct is so big it would be annoying to manually implement Decode.