### PR TITLE
Fix unaligned disk reads for xattrs

### DIFF
--- a/src/libxfuse/attr.rs
+++ b/src/libxfuse/attr.rs
@@ -163,17 +163,6 @@ pub struct AttrLeafblock {
 }
 
 impl AttrLeafblock {
-    pub fn from<R: Reader + BufRead + Seek>(buf_reader: &mut R) -> AttrLeafblock {
-        let hdr: AttrLeafHdr = decode_from(buf_reader.by_ref()).unwrap();
-
-        let mut entries = Vec::<AttrLeafEntry>::with_capacity(hdr.count.into());
-        for _i in 0..entries.capacity() {
-            entries.push(AttrLeafEntry::from(buf_reader.by_ref()));
-        }
-
-        AttrLeafblock { hdr, entries }
-    }
-
     pub fn get_total_size<R: BufRead + Reader + Seek>(
         &mut self,
         buf_reader: &mut R,

--- a/src/libxfuse/attr.rs
+++ b/src/libxfuse/attr.rs
@@ -46,7 +46,8 @@ use super::{
     da_btree::{XfsDa3Blkinfo, XfsDa3Intnode},
     definitions::{XFS_ATTR3_LEAF_MAGIC, XFS_DA3_NODE_MAGIC, XfsFileoff, XfsFsblock},
     sb::Sb,
-    utils::{self, decode_from}
+    utils,
+    volume::SUPERBLOCK
 };
 
 #[allow(dead_code)]
@@ -120,22 +121,6 @@ pub struct AttrLeafEntry {
     pub pad2: u8,
 }
 
-impl AttrLeafEntry {
-    pub fn from<R: BufRead>(buf_reader: &mut R) -> AttrLeafEntry {
-        let hashval = buf_reader.read_u32::<BigEndian>().unwrap();
-        let nameidx = buf_reader.read_u16::<BigEndian>().unwrap();
-        let flags = buf_reader.read_u8().unwrap();
-        let pad2 = buf_reader.read_u8().unwrap();
-
-        AttrLeafEntry {
-            hashval,
-            nameidx,
-            flags,
-            pad2,
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct AttrLeafNameLocal {
     pub valuelen: u16,
@@ -155,94 +140,100 @@ impl Decode for AttrLeafNameLocal {
 }
 
 #[derive(Debug)]
+pub enum AttrLeafName {
+    Local(AttrLeafNameLocal),
+    Remote(AttrLeafNameRemote)
+}
+
+impl AttrLeafName {
+    fn name(&self) -> &[u8] {
+        match self {
+            AttrLeafName::Local(local) => &local.nameval[0..usize::from(local.namelen)],
+            AttrLeafName::Remote(remote) => &remote.name[0..usize::from(remote.namelen)],
+        }
+    }
+
+    fn namelen(&self) -> u8 {
+        match self {
+            AttrLeafName::Local(local) => local.namelen,
+            AttrLeafName::Remote(remote) => remote.namelen,
+        }
+    }
+
+    fn value<F, R>(
+        &self,
+        buf_reader: &mut R,
+        map_logical_block_to_fs_block: F,
+    ) -> Vec<u8>
+        where R: BufRead + Reader + Seek,
+              F: Fn(XfsFileoff, &mut R) -> XfsFsblock
+    {
+        match self {
+            AttrLeafName::Local(local) => {
+                local.nameval[local.namelen as usize..].to_vec()
+            },
+            AttrLeafName::Remote(remote) => {
+                let blocksize = u64::from(SUPERBLOCK.get().unwrap().sb_blocksize);
+                let mut res: Vec<u8> = Vec::with_capacity(remote.valuelen as usize);
+                let mut valueblk = remote.valueblk.into();
+                let mut valuelen: i64 = remote.valuelen.into();
+
+                while valuelen > 0 {
+                    let blk_num =
+                        map_logical_block_to_fs_block(valueblk, buf_reader.by_ref());
+                    buf_reader.seek(SeekFrom::Start(blk_num * blocksize)).unwrap();
+
+                    let (_, data) = AttrRmtHdr::from(buf_reader.by_ref());
+
+                    valuelen -= data.len() as i64;
+                    res.extend(data);
+                    valueblk += 1;
+                }
+                res
+            }
+        }
+    }
+
+    fn valuelen(&self) -> u32 {
+        match self {
+            AttrLeafName::Local(local) => local.valuelen.into(),
+            AttrLeafName::Remote(remote) => remote.valuelen,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct AttrLeafblock {
     pub hdr: AttrLeafHdr,
+    // TODO: in-memory, combine AttrLeafEntry and AttrLeafName into a struct, so we'll only need a
+    // single Vec
     pub entries: Vec<AttrLeafEntry>,
-    // pub namelist: AttrLeafNameLocal,
-    // pub valuelist: AttrLeafNameRemote,
+    pub names: Vec<AttrLeafName>
 }
 
 impl AttrLeafblock {
-    pub fn get_total_size<R: BufRead + Reader + Seek>(
-        &mut self,
-        buf_reader: &mut R,
-        leaf_offset: u64,
-    ) -> u32 {
-        let mut total_size: u32 = 0;
+    pub fn get_total_size(&mut self) -> u32 {
+        let mut total: u32 = 0;
 
-        for entry in self.entries.iter() {
-            buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
-            buf_reader
-                .seek(SeekFrom::Current(i64::from(entry.nameidx)))
-                .unwrap();
-
-            if entry.flags & constants::XFS_ATTR_LOCAL != 0 {
-                let name_entry: AttrLeafNameLocal = decode_from(buf_reader.by_ref()).unwrap();
-                total_size +=
-                    get_namespace_size_from_flags(entry.flags) + u32::from(name_entry.namelen) + 1;
-            } else {
-                let name_entry: AttrLeafNameRemote = decode_from(buf_reader.by_ref()).unwrap();
-                total_size +=
-                    get_namespace_size_from_flags(entry.flags) + u32::from(name_entry.namelen) + 1;
-            }
+        for (entry, name) in std::iter::zip(self.entries.iter(), self.names.iter()) {
+            total += get_namespace_size_from_flags(entry.flags) + u32::from(name.namelen()) + 1;
         }
 
-        total_size
+        total
     }
 
-    pub fn get_size<R: BufRead + Reader + Seek>(
-        &self,
-        buf_reader: &mut R,
-        hash: u32,
-        leaf_offset: u64,
-    ) -> Result<u32, libc::c_int> {
+    pub fn get_size(&self, hash: u32) -> Result<u32, libc::c_int> {
+        // TODO: handle hash collisions
         match self.entries.binary_search_by_key(&hash, |entry| entry.hashval) {
-            Ok(i) => {
-                // TODO: read all of these into the struct instead of reading them here
-                let entry = &self.entries[i];
-                buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
-                buf_reader
-                    .seek(SeekFrom::Current(i64::from(entry.nameidx)))
-                    .unwrap();
-
-                if entry.flags & constants::XFS_ATTR_LOCAL != 0 {
-                    let name_entry: AttrLeafNameLocal = decode_from(buf_reader.by_ref()).unwrap();
-                    Ok(name_entry.valuelen.into())
-                } else {
-                    let name_entry: AttrLeafNameRemote = decode_from(buf_reader.by_ref()).unwrap();
-                    Ok(name_entry.valuelen)
-                }
-            },
+            Ok(i) => Ok(self.names[i].valuelen()),
             Err(_) => Err(libc::ENOATTR)
         }
     }
 
-    pub fn list<R: BufRead + Reader + Seek>(
-        &mut self,
-        buf_reader: &mut R,
-        list: &mut Vec<u8>,
-        leaf_offset: u64,
-    ) {
-        for entry in self.entries.iter() {
-            buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
-            buf_reader
-                .seek(SeekFrom::Current(i64::from(entry.nameidx)))
-                .unwrap();
-
-            if entry.flags & constants::XFS_ATTR_LOCAL != 0 {
-                let name_entry: AttrLeafNameLocal = decode_from(buf_reader.by_ref()).unwrap();
-
-                list.extend_from_slice(get_namespace_from_flags(entry.flags));
-                let namelen = name_entry.namelen as usize;
-                list.extend_from_slice(&name_entry.nameval[0..namelen]);
-            } else {
-                let name_entry: AttrLeafNameRemote = decode_from(buf_reader.by_ref()).unwrap();
-
-                list.extend_from_slice(get_namespace_from_flags(entry.flags));
-                let namelen = name_entry.namelen as usize;
-                list.extend_from_slice(&name_entry.name[0..namelen]);
-            }
-
+    pub fn list(&mut self, list: &mut Vec<u8>) {
+        for (entry, name_entry) in std::iter::zip(self.entries.iter(), self.names.iter()) {
+            list.extend_from_slice(get_namespace_from_flags(entry.flags));
+            list.extend_from_slice(name_entry.name());
             list.push(0)
         }
     }
@@ -252,52 +243,11 @@ impl AttrLeafblock {
     pub fn get<R: BufRead + Reader + Seek, F: Fn(XfsFileoff, &mut R) -> XfsFsblock>(
         &self,
         buf_reader: &mut R,
-        super_block: &Sb,
         hash: u32,
-        leaf_offset: u64,
         map_logical_block_to_fs_block: F,
     ) -> Vec<u8> {
         match self.entries.binary_search_by_key(&hash, |entry| entry.hashval) {
-            Ok(i) => {
-                // TODO: read all of these into the struct instead of reading them here
-                let entry = &self.entries[i];
-                buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
-                buf_reader
-                    .seek(SeekFrom::Current(i64::from(entry.nameidx)))
-                    .unwrap();
-
-                if entry.flags & constants::XFS_ATTR_LOCAL != 0 {
-                    let name_entry: AttrLeafNameLocal = decode_from(buf_reader.by_ref()).unwrap();
-
-                    let namelen = name_entry.namelen as usize;
-
-                    name_entry.nameval[namelen..].to_vec()
-                } else {
-                    let name_entry: AttrLeafNameRemote = decode_from(buf_reader.by_ref()).unwrap();
-
-                    let mut valuelen: i64 = name_entry.valuelen.into();
-                    let mut valueblk = name_entry.valueblk;
-
-                    let mut res: Vec<u8> = Vec::with_capacity(valuelen as usize);
-
-                    while valuelen > 0 {
-                        let blk_num =
-                            map_logical_block_to_fs_block(valueblk.into(), buf_reader.by_ref());
-                        buf_reader
-                            .seek(SeekFrom::Start(
-                                blk_num * u64::from(super_block.sb_blocksize),
-                            ))
-                            .unwrap();
-
-                        let (_, data) = AttrRmtHdr::from(buf_reader.by_ref());
-
-                        valuelen -= data.len() as i64;
-                        res.extend(data);
-                        valueblk += 1;
-                    }
-                    res
-                }
-            },
+            Ok(i) => self.names[i].value(buf_reader, map_logical_block_to_fs_block),
             Err(_) => panic!("Couldn't find the attribute entry")
         }
     }
@@ -305,14 +255,35 @@ impl AttrLeafblock {
 
 impl Decode for AttrLeafblock {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let hdr: AttrLeafHdr = Decode::decode(decoder)?;
+        let blocksize = SUPERBLOCK.get().unwrap().sb_blocksize as usize;
+        let mut raw = vec![0u8; blocksize];
+        decoder.reader().read(&mut raw[..])?;
+
+        let config = decoder.config();
+        let sl = bincode::de::read::SliceReader::new(&raw);
+        let mut sldecoder = bincode::de::DecoderImpl::new(sl, *config);
+        let hdr: AttrLeafHdr = Decode::decode(&mut sldecoder)?;
 
         let mut entries = Vec::<AttrLeafEntry>::with_capacity(hdr.count.into());
         for _i in 0..entries.capacity() {
-            entries.push(Decode::decode(decoder)?);
+            entries.push(Decode::decode(&mut sldecoder)?);
         }
 
-        Ok(AttrLeafblock {hdr, entries})
+        let mut names = Vec::with_capacity(entries.len());
+        for e in entries.iter() {
+            let ofs = usize::from(e.nameidx);
+            if e.flags & constants::XFS_ATTR_LOCAL != 0 {
+                let local = bincode::decode_from_slice(&raw[ofs..], *config)?.0;
+                names.push(AttrLeafName::Local(local));
+            } else {
+                let remote = bincode::decode_from_slice(&raw[ofs..], *config)?.0;
+                names.push(AttrLeafName::Remote(remote));
+            }
+        }
+
+        Ok(AttrLeafblock {hdr, entries,
+            names
+        })
     }
 }
 

--- a/src/libxfuse/attr_bptree.rs
+++ b/src/libxfuse/attr_bptree.rs
@@ -38,6 +38,7 @@ use super::{
     btree::{Btree, BtreeRoot},
     da_btree::{hashname, XfsDa3Intnode},
     sb::Sb,
+    utils::decode_from
 };
 
 #[derive(Debug)]
@@ -70,7 +71,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
 
             buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
-            let mut leaf = AttrLeafblock::from(buf_reader.by_ref());
+            let mut leaf: AttrLeafblock = decode_from(buf_reader.by_ref()).unwrap();
             total_size += leaf.get_total_size(buf_reader.by_ref(), leaf_offset);
 
             while leaf.hdr.info.forw != 0 {
@@ -78,7 +79,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
                     leaf.hdr.info.forw.into()).unwrap();
                 let lfofs = lfblk * u64::from(super_block.sb_blocksize);
                 buf_reader.seek(SeekFrom::Start(lfofs)).unwrap();
-                leaf = AttrLeafblock::from(buf_reader.by_ref());
+                leaf = decode_from(buf_reader.by_ref()).unwrap();
                 total_size += leaf.get_total_size(buf_reader.by_ref(), lfofs);
             }
 
@@ -114,7 +115,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
         loop {
-            let leaf = AttrLeafblock::from(buf_reader.by_ref());
+            let leaf: AttrLeafblock = decode_from(buf_reader.by_ref()).unwrap();
 
             match leaf.get_size(buf_reader.by_ref(), hash, leaf_offset) {
                 Ok(l) => return Ok(l),
@@ -148,7 +149,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
 
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
-        let mut leaf = AttrLeafblock::from(buf_reader.by_ref());
+        let mut leaf: AttrLeafblock = decode_from(buf_reader.by_ref()).unwrap();
         leaf.list(buf_reader.by_ref(), &mut list, leaf_offset);
 
         while leaf.hdr.info.forw != 0 {
@@ -156,7 +157,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
                 leaf.hdr.info.forw.into()).unwrap();
             let lfofs = lfblk * u64::from(super_block.sb_blocksize);
             buf_reader.seek(SeekFrom::Start(lfofs)).unwrap();
-            leaf = AttrLeafblock::from(buf_reader.by_ref());
+            leaf = decode_from(buf_reader.by_ref()).unwrap();
             leaf.list(buf_reader.by_ref(), &mut list, lfofs);
         }
 
@@ -181,7 +182,7 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
 
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
-        let leaf = AttrLeafblock::from(buf_reader.by_ref());
+        let leaf: AttrLeafblock = decode_from(buf_reader.by_ref()).unwrap();
 
         return Ok(leaf.get(
             buf_reader.by_ref(),

--- a/src/libxfuse/attr_leaf.rs
+++ b/src/libxfuse/attr_leaf.rs
@@ -31,6 +31,8 @@ use std::{
     io::{BufRead, Seek},
 };
 
+use bincode::de::read::Reader;
+
 use super::{
     attr::{Attr, AttrLeafblock},
     bmbt_rec::BmbtRec,
@@ -61,7 +63,7 @@ impl AttrLeaf {
     }
 }
 
-impl<R: BufRead + Seek> Attr<R> for AttrLeaf {
+impl<R: BufRead + Reader + Seek> Attr<R> for AttrLeaf {
     fn get_total_size(&mut self, buf_reader: &mut R, _super_block: &Sb) -> u32 {
         if self.total_size != -1 {
             self.total_size.try_into().unwrap()


### PR DESCRIPTION
When reading an AttrLeafblock from disk, fully deserialize the entire disk block and store it in memory.  That way we won't have to do any more disk reads during ::get , ::list , etc.  Those unaligned reads would fail if the disk image was stored in a device file.
