### PR TITLE
Fix reading data from some BTree-formatted files

### DIFF
--- a/scripts/mkimg.sh
+++ b/scripts/mkimg.sh
@@ -225,6 +225,10 @@ mkfs_512() {
 	fill_file ${MNTDIR}/files/btree3.txt 1024 2048
 	fill_file ${MNTDIR}/files/btree3.3.txt 1024 8192
 
+	# Create a regular file that also has an xattr
+	fill_file ${MNTDIR}/files/btree2_with_xattrs.txt 1024 64
+	setfattr -n user.foo -v bar ${MNTDIR}/files/btree2_with_xattrs.txt
+
 	# Allocate a file with a BTree extent list for its xattrs.  This is
 	# unreliable; more xattrs don't necessarily result in a BTree extent
 	# list.  After changing this script, double check that it's still a

--- a/src/libxfuse/dinode.rs
+++ b/src/libxfuse/dinode.rs
@@ -145,7 +145,10 @@ impl Dinode {
                     let space = if di_core.di_forkoff == 0 {
                         (usize::from(superblock.sb_inodesize) - LITERAL_AREA_OFFSET) / 2
                     } else {
-                        usize::from(di_core.di_forkoff) * 8 / 2
+                        let space = usize::from(di_core.di_forkoff) * 8 / 2;
+                        // Round up to a multiple of 8
+                        let rem = space % 8;
+                        if rem == 0 { space } else { space + 8 - rem }
                     };
                     let gap = space -
                         BmdrBlock::SIZE -
@@ -197,7 +200,11 @@ impl Dinode {
                     let space = if di_core.di_forkoff == 0 {
                         (usize::from(superblock.sb_inodesize) - LITERAL_AREA_OFFSET) / 2
                     } else {
-                        usize::from(di_core.di_forkoff) * 8 / 2
+                        let space = usize::from(di_core.di_forkoff) * 8 / 2;
+                        // Round up to a multiple of 8.  This is probably necessary, but I've never
+                        // seen a directory like this in practice.
+                        let rem = space % 8;
+                        if rem == 0 { space } else { space + 8 - rem }
                     };
                     let gap = space -
                         BmdrBlock::SIZE -

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -806,6 +806,7 @@ mod read {
     #[case::wide_two_height_btree2(harness1k, "btree2.2.txt", 65536)]
     #[case::wide_two_height_btree2(harness1k, "btree3.txt", 2097152)]
     #[case::wide_two_height_btree2(harness1k, "btree3.3.txt", 8388608)]
+    #[case::btree_with_xattr(harness1k, "btree2_with_xattrs.txt", 65536)]
     fn all_files(h: fn() -> Harness, d: &str) {}
 
     /// Attempting to read across eof should return the correct amount of data


### PR DESCRIPTION
In a BTree-formatted file, the precise location of the bmbt pointers is not documented.  It seems from experiment that the location always lies at a byte address divisible by 8.  This matters for some files that have xattrs.  The precise length of the xattr probably matters.

I don't know, for lack of real-world examples, whether this same adjustment is necessary for directories.  But I assume it is.