### PR TITLE
Factor out some common code

### DIFF
--- a/src/libxfuse/dinode_core.rs
+++ b/src/libxfuse/dinode_core.rs
@@ -137,7 +137,9 @@ impl DinodeCore {
 
     pub fn stat(&self, ino: XfsIno) -> Result<FileAttr, c_int> {
         let kind = get_file_type(FileKind::Mode(self.di_mode))?;
-        assert_eq!(ino, self.di_ino);
+        // Special case for ino 1.  FUSE requires / to have inode 1, but XFS
+        // does not.
+        assert!(ino == 1 || ino == self.di_ino);
         Ok(FileAttr {
                 ino,
                 size: self.di_size as u64,

--- a/src/libxfuse/dir3_leaf.rs
+++ b/src/libxfuse/dir3_leaf.rs
@@ -29,9 +29,7 @@ use std::cell::RefCell;
 use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, Seek, SeekFrom};
 use std::mem;
-use std::time::{Duration, UNIX_EPOCH};
 
-use super::S_IFMT;
 use super::bmbt_rec::BmbtRec;
 use super::da_btree::hashname;
 use super::definitions::*;
@@ -124,35 +122,7 @@ impl<R: bincode::de::read::Reader + BufRead + Seek> Dir3<R> for Dir2Leaf {
         };
 
         let dinode = Dinode::from(buf_reader.by_ref(), super_block, entry.inumber);
-
-        let kind = get_file_type(FileKind::Mode(dinode.di_core.di_mode))?;
-
-        let attr = FileAttr {
-            ino: entry.inumber,
-            size: dinode.di_core.di_size as u64,
-            blocks: dinode.di_core.di_nblocks,
-            atime: UNIX_EPOCH + Duration::new(
-                dinode.di_core.di_atime.t_sec as u64,
-                dinode.di_core.di_atime.t_nsec,
-            ),
-            mtime: UNIX_EPOCH + Duration::new(
-                dinode.di_core.di_mtime.t_sec as u64,
-                dinode.di_core.di_mtime.t_nsec,
-            ),
-            ctime: UNIX_EPOCH + Duration::new(
-                dinode.di_core.di_ctime.t_sec as u64,
-                dinode.di_core.di_ctime.t_nsec,
-            ),
-            crtime: UNIX_EPOCH,
-            kind,
-            perm: dinode.di_core.di_mode & !S_IFMT,
-            nlink: dinode.di_core.di_nlink,
-            uid: dinode.di_core.di_uid,
-            gid: dinode.di_core.di_gid,
-            rdev: 0,
-            blksize: 0,
-            flags: 0,
-        };
+        let attr = dinode.di_core.stat(entry.inumber)?;
 
         Ok((attr, dinode.di_core.di_gen.into()))
     }


### PR DESCRIPTION
This was an oversight from f4408c36 .  Factoring it out also contains 2 bug fixes:

* Fixes reading timestamps in leaf directories and during FUSE_GETATTR (which should be very rarely used in xfuse).
* Fixes a crash that would happen when stating a link, fifo, or device file during FUSE_GETATTR.