### PR TITLE
Refactor directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1170,7 @@ dependencies = [
  "byteorder",
  "clap",
  "crc",
+ "enum_dispatch",
  "function_name",
  "fuser",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 bincode = {version = "2.0.0-rc.3", default-features = false, features = ["derive", "std"]}
 byteorder = "1.4.3"
 crc = "2.0.0"
+enum_dispatch = "0.3.12"
 fuser = "0.13.0"
 libc = "0.2.97"
 num-derive = "0.4.2"

--- a/scripts/mkimg.sh
+++ b/scripts/mkimg.sh
@@ -101,7 +101,6 @@ mkfs_4096() {
 	mkfiles ${MNTDIR}/sf 2
 	mkfiles ${MNTDIR}/block 32
 	mkfiles ${MNTDIR}/leaf 384
-	mkfiles ${MNTDIR}/node 1024
 
 	# Make a block directory with hash collisions.
 	# shortform directories cannot have hash collisions (because they don't use hashes).
@@ -190,6 +189,13 @@ mkfs_512() {
 	##
 	# With 1k blocks and 4k directories
 	# nfiles
+	# 64		255	leaf	N/A		5 data 1 leaf
+	# 256		255	leaf	N/A		6 data 1 leaf
+	# 384		255	leaf	N/A		7 data 1 leaf
+	# 448		255	leaf	N/A		8 data 1 leaf
+	# 480		255	leaf	N/A		8 data l leaf
+	# 496		255	node	N/A		8 data 2 leaf
+	# 512		255	node	N/A		9 data 3 leaf
 	# 4096		255	btree	1		2
 	# 8192		255	btree	1		3
 	# 16384		255	btree	1		5
@@ -197,6 +203,9 @@ mkfs_512() {
 	# 65536		255	btree	1		18
 	# 131072	255	btree	2		1
 	# 262144	255	btree	2		2
+	mkfiles2 ${MNTDIR}/leaf 256
+	mkfiles2 ${MNTDIR}/node1 496
+	mkfiles2 ${MNTDIR}/node3 512
 	mkfiles2 ${MNTDIR}/btree2.3 8192
 	mkfiles2 ${MNTDIR}/btree3 131072
 

--- a/src/libxfuse/btree.rs
+++ b/src/libxfuse/btree.rs
@@ -112,11 +112,11 @@ pub trait Btree {
             .map_err(|e| e.raw_os_error().unwrap())?;
 
         if self.level() > 1 {
-            let bti: BtreeIntermediate = decode_from(buf_reader.by_ref()).map_err(|_| libc::EIO)?;
+            let bti: BtreeIntermediate = decode_from(buf_reader.by_ref()).map_err(|_| libc::EDESTADDRREQ)?;
             assert_eq!(bti.hdr.bb_uuid, super_block.sb_uuid);
             bti.map_block(buf_reader, logical_block)
         } else {
-            let btl: BtreeLeaf = decode_from(buf_reader.by_ref()).map_err(|_| libc::EIO)?;
+            let btl: BtreeLeaf = decode_from(buf_reader.by_ref()).map_err(|_| libc::ENOTSOCK)?;
             assert_eq!(btl.hdr.bb_uuid, super_block.sb_uuid);
             Ok(btl.get_extent(logical_block))
         }

--- a/src/libxfuse/dir3_leaf.rs
+++ b/src/libxfuse/dir3_leaf.rs
@@ -30,6 +30,8 @@ use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, Seek, SeekFrom};
 use std::mem;
 
+use tracing::warn;
+
 use super::bmbt_rec::BmbtRec;
 use super::da_btree::hashname;
 use super::definitions::*;
@@ -64,6 +66,9 @@ impl Dir2Leaf {
         }
 
         let leaf_extent = bmx.last().unwrap();
+        if leaf_extent.br_startblock != superblock.get_dir3_leaf_offset() {
+            warn!("Leaf directory contains unexpected bmx entry {:?}", &leaf_extent);
+        }
         let offset = superblock.fsb_to_offset(leaf_extent.br_startblock);
 
         let leaf_size = leaf_extent.br_blockcount as usize * superblock.sb_blocksize as usize;

--- a/src/libxfuse/dir3_leaf.rs
+++ b/src/libxfuse/dir3_leaf.rs
@@ -25,30 +25,66 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-use std::cell::RefCell;
-use std::ffi::{OsStr, OsString};
-use std::io::{BufRead, Seek, SeekFrom};
-use std::mem;
+use std::{
+    cell::{Ref, RefCell},
+    io::{BufRead, Seek, SeekFrom},
+    ops::Deref
+};
+
+use bincode::{de::read::Reader, Decode};
 
 use tracing::warn;
 
 use super::bmbt_rec::BmbtRec;
-use super::da_btree::hashname;
 use super::definitions::*;
-use super::dinode::Dinode;
-use super::dir3::{Dir2Data, Dir2DataEntry, Dir2DataUnused, Dir2LeafDisk, Dir3, Dir3DataHdr};
+use super::dir3::{Dir2Data, Dir2LeafEntry, Dir3, Dir3LeafHdr, XfsDir2Dataptr};
 use super::sb::Sb;
-use super::utils::{decode, get_file_type, FileKind};
 
-use fuser::{FileAttr, FileType};
-use libc::{c_int, ENOENT};
+#[derive(Debug)]
+struct Dir2LeafDisk {
+    pub hdr: Dir3LeafHdr,
+    pub ents: Vec<Dir2LeafEntry>,
+    // bests: not needed for a read-only implementation of XFS
+    // tail:  not needed for a read-only implementation of XFS
+}
+
+impl Dir2LeafDisk {
+    pub fn from<T: BufRead + Seek>(
+        buf_reader: &mut T,
+        offset: u64,
+        size: usize,
+    ) -> Dir2LeafDisk {
+        buf_reader.seek(SeekFrom::Start(offset)).unwrap();
+        let mut raw = vec![0u8; size];
+        buf_reader.read_exact(&mut raw).unwrap();
+        let config = bincode::config::standard()
+            .with_big_endian()
+            .with_fixed_int_encoding();
+        let reader = bincode::de::read::SliceReader::new(&raw[..]);
+        let mut decoder = bincode::de::DecoderImpl::new(reader, config);
+        let hdr = Dir3LeafHdr::decode(&mut decoder).unwrap();
+        assert_eq!(hdr.info.magic, XFS_DIR3_LEAF1_MAGIC,
+            "bad magic! expected {:#x} but found {:#x}", XFS_DIR3_LEAF1_MAGIC, hdr.info.magic);
+
+        let ents = (0..hdr.count).map(|_| {
+            Dir2LeafEntry::decode(&mut decoder).unwrap()
+        }).collect::<Vec<_>>();
+
+        Dir2LeafDisk {
+            hdr,
+            ents,
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct Dir2Leaf {
+    bmx: Vec<BmbtRec>,
     pub entries: Vec<Dir2Data>,
-    pub leaf: Dir2LeafDisk,
-    /// An cache of the last block and its index read by lookup or readdir.
-    block_cache: RefCell<Option<(usize, Vec<u8>)>>
+    leaf: Dir2LeafDisk,
+    /// A cache of the last extent and its starting block number read by lookup
+    /// or readdir.
+    block_cache: RefCell<(XfsFsblock, Vec<u8>)>
 }
 
 impl Dir2Leaf {
@@ -75,130 +111,67 @@ impl Dir2Leaf {
         let leaf = Dir2LeafDisk::from(buf_reader, offset, leaf_size);
         assert_eq!(leaf.hdr.info.magic, XFS_DIR3_LEAF1_MAGIC);
 
+        let dblksize: usize = 1 << (superblock.sb_blocklog + superblock.sb_dirblklog);
+        let block_cache = RefCell::new((XfsFsblock::max_value(), Vec::with_capacity(dblksize)));
+
         Dir2Leaf {
+            bmx: bmx.to_vec(),
             entries,
             leaf,
-            block_cache: RefCell::new(None)
+            block_cache
         }
+    }
+
+    fn map_dblock(&self, dblock: XfsDablk) -> Result<XfsFsblock, i32> {
+        let dblock = u64::from(dblock);
+
+        let i = self.bmx.partition_point(|rec| rec.br_startoff <= dblock);
+        let rec = &self.bmx[i - 1];
+        if i == 0 || rec.br_startoff > dblock || rec.br_startoff + rec.br_blockcount <= dblock {
+            Err(libc::ENOENT)
+        } else {
+            Ok(rec.br_startblock + dblock - rec.br_startoff)
+        }
+    }
+
+    fn read_fsblock<'a, R>(&'a self, mut buf_reader: R, sb: &Sb, fsblock: XfsFsblock)
+        -> Result<Box<dyn Deref<Target=[u8]> + 'a>, i32>
+        where R: Reader + BufRead + Seek
+    {
+        let dblksize: usize = 1 << (sb.sb_blocklog + sb.sb_dirblklog);
+
+        let mut cache_guard = self.block_cache.borrow_mut();
+        if cache_guard.0 != fsblock || cache_guard.1.len() != dblksize {
+            cache_guard.1.resize(dblksize, 0u8);
+            buf_reader
+                .seek(SeekFrom::Start(sb.fsb_to_offset(fsblock)))
+                .unwrap();
+            buf_reader.read_exact(&mut cache_guard.1).unwrap();
+            cache_guard.0 = fsblock;
+        }
+        // Annoyingly, there's no function to downgrade a RefMut into a Ref.
+        drop(cache_guard);
+        let cache_guard = self.block_cache.borrow();
+        Ok(Box::new(Ref::map(cache_guard, |v| v.1.as_ref())))
     }
 }
 
-impl<R: bincode::de::read::Reader + BufRead + Seek> Dir3<R> for Dir2Leaf {
-    fn lookup(
-        &self,
-        buf_reader: &mut R,
-        super_block: &Sb,
-        name: &OsStr,
-    ) -> Result<(FileAttr, u64), c_int> {
-        let dblksize: usize = super_block.sb_blocksize as usize *
-            (1 << super_block.sb_dirblklog) as usize;
-        let hash = hashname(name);
-        let mut collision_resolver = 0;
-
-        let entry = loop {
-            let address = self.leaf.get_address(hash, collision_resolver)? as usize * 8;
-            let idx = (address / dblksize) as usize;
-            let address = (address % dblksize) as usize;
-
-            if idx >= self.entries.len() {
-                return Err(ENOENT);
-            }
-
-            let d2d: &Dir2Data = &self.entries[idx];
-
-            let mut cache_guard = self.block_cache.borrow_mut();
-            if cache_guard.is_none() || cache_guard.as_ref().unwrap().0 != idx {
-                let mut raw = vec![0u8; dblksize];
-                buf_reader
-                    .seek(SeekFrom::Start(d2d.offset))
-                    .unwrap();
-                buf_reader.read_exact(&mut raw).unwrap();
-                *cache_guard = Some((idx, raw));
-            }
-            let raw = &cache_guard.as_ref().unwrap().1;
-
-            let entry: Dir2DataEntry = decode(&raw[address..]).unwrap().0;
-            if entry.name == name {
-                break entry;
-            } else {
-                // A hash collision, probably
-                collision_resolver += 1;
-            }
-        };
-
-        let dinode = Dinode::from(buf_reader.by_ref(), super_block, entry.inumber);
-        let attr = dinode.di_core.stat(entry.inumber)?;
-
-        Ok((attr, dinode.di_core.di_gen.into()))
+impl Dir3 for Dir2Leaf {
+    fn get_addresses<'a, R>(&'a self, _buf_reader: &'a RefCell<&'a mut R>, hash: XfsDahash)
+        -> Box<dyn Iterator<Item=XfsDir2Dataptr> + 'a>
+            where R: Reader + BufRead + Seek + 'a
+    {
+        let i = self.leaf.ents.partition_point(|ent| ent.hashval < hash);
+        let l = self.leaf.ents.len();
+        let j = (i..l).find(|x| self.leaf.ents[*x].hashval > hash).unwrap_or(l);
+        Box::new(self.leaf.ents[i..j].iter().map(|ent| ent.address << 3))
     }
 
-    fn next(
-        &self,
-        buf_reader: &mut R,
-        super_block: &Sb,
-        offset: i64,
-    ) -> Result<(XfsIno, i64, FileType, OsString), c_int> {
-        let dblksize = super_block.sb_blocksize as usize * (1 << super_block.sb_dirblklog);
-        let offset = offset as u64;
-        // In V5 Inodes can contain up to 21 Extents
-        let mut idx: usize = (offset >> (64 - 8)) as usize;
-        if idx >= self.entries.len() {
-            return Err(ENOENT);
-        }
-        let mut entry: &Dir2Data = &self.entries[idx];
-
-        let mut offset = (offset & ((1 << (64 - 8)) - 1)) as usize;
-
-        let mut next = offset == 0;
-        loop {
-            offset = if offset == 0 {
-                mem::size_of::<Dir3DataHdr>()
-            } else {
-                offset
-            };
-
-            let mut cache_guard = self.block_cache.borrow_mut();
-            if cache_guard.is_none() || cache_guard.as_ref().unwrap().0 != idx {
-                let mut raw = vec![0u8; dblksize];
-                buf_reader
-                    .seek(SeekFrom::Start(entry.offset))
-                    .unwrap();
-                buf_reader.read_exact(&mut raw).unwrap();
-                *cache_guard = Some((idx, raw));
-            }
-            let raw = &cache_guard.as_ref().unwrap().1;
-
-            while offset < raw.len() {
-                let freetag: u16 = decode(&raw[offset..]).unwrap().0;
-
-                if freetag == 0xffff {
-                    let (_, length) = decode::<Dir2DataUnused>(&raw[offset..])
-                        .unwrap();
-                    offset += length;
-                } else if next {
-                    let entry: Dir2DataEntry = decode(&raw[offset..]).unwrap().0;
-                    let kind = get_file_type(FileKind::Type(entry.ftype))?;
-                    let name = entry.name;
-                    let tag = ((idx as u64) << (64 - 8)) | (entry.tag as u64);
-                    return Ok((entry.inumber, tag as i64, kind, name));
-                } else {
-                    let length = Dir2DataEntry::get_length(&raw[offset..]);
-                    offset += length as usize;
-
-                    next = true;
-                }
-            }
-
-            idx += 1;
-
-            if idx >= self.entries.len() {
-                break;
-            }
-            entry = &self.entries[idx];
-
-            offset = 0;
-        }
-
-        Err(ENOENT)
+    fn read_dblock<'a, R>(&'a self, mut buf_reader: R, sb: &Sb, dblock: XfsDablk)
+        -> Result<Box<dyn Deref<Target=[u8]> + 'a>, i32>
+        where R: Reader + BufRead + Seek
+    {
+        let fsblock = self.map_dblock(dblock)?;
+        self.read_fsblock(buf_reader.by_ref(), sb, fsblock)
     }
 }

--- a/src/libxfuse/dir3_node.rs
+++ b/src/libxfuse/dir3_node.rs
@@ -57,7 +57,7 @@ impl Dir2Node {
         }
     }
 
-    pub fn map_dblock(&self, dblock: XfsFileoff) -> Option<&BmbtRec> {
+    fn map_dblock(&self, dblock: XfsFileoff) -> Option<&BmbtRec> {
         let mut res: Option<&BmbtRec> = None;
         for record in self.bmx.iter().rev() {
             if dblock >= record.br_startoff {
@@ -75,7 +75,7 @@ impl Dir2Node {
         res
     }
 
-    pub fn map_dblock_number(&self, dblock: XfsFileoff) -> XfsFsblock {
+    fn map_dblock_number(&self, dblock: XfsFileoff) -> XfsFsblock {
         for record in self.bmx.iter().rev() {
             if dblock >= record.br_startoff {
                 return record.br_startblock + (dblock - record.br_startoff);

--- a/src/libxfuse/dir3_sf.rs
+++ b/src/libxfuse/dir3_sf.rs
@@ -194,8 +194,8 @@ impl Decode for Dir2Sf {
     }
 }
 
-impl<R: bincode::de::read::Reader + BufRead + Seek> Dir3<R> for Dir2Sf {
-    fn lookup(
+impl Dir3 for Dir2Sf {
+    fn lookup<R: bincode::de::read::Reader + BufRead + Seek>(
         &self,
         buf_reader: &mut R,
         super_block: &Sb,
@@ -220,7 +220,7 @@ impl<R: bincode::de::read::Reader + BufRead + Seek> Dir3<R> for Dir2Sf {
         }
     }
 
-    fn next(
+    fn next<R: bincode::de::read::Reader + BufRead + Seek>(
         &self,
         _buf_reader: &mut R,
         _super_block: &Sb,

--- a/src/libxfuse/mod.rs
+++ b/src/libxfuse/mod.rs
@@ -40,6 +40,7 @@ mod dinode_core;
 mod dir3;
 mod dir3_block;
 mod dir3_bptree;
+//mod dir3_extents;
 mod dir3_leaf;
 mod dir3_node;
 mod dir3_sf;

--- a/src/libxfuse/volume.rs
+++ b/src/libxfuse/volume.rs
@@ -35,6 +35,7 @@ use std::time::Duration;
 use super::agi::Agi;
 use super::definitions::XfsIno;
 use super::dinode::Dinode;
+use super::dir3::Dir3;
 use super::sb::Sb;
 
 use fuser::{

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -109,6 +109,9 @@ fn remote_attrs_per_file(f: &str) -> usize {
 // This is a function of the golden image creation.
 fn ents_per_dir_1k(d: &str) -> usize {
     match d {
+        "leaf" => 256,
+        "node1" => 496,
+        "node3" => 512,
         "btree2.with-xattrs" => 1024,
         "btree2.3" => 8192,
         "btree3" => 131072,
@@ -357,6 +360,12 @@ impl Drop for MdHarness {
 
 #[template]
 #[rstest]
+// Leaf directory with > 4 directory blocks
+#[case::leaf("leaf")]
+// Node directory with a single leaf block
+#[case::node1("node1")]
+// Node directory with multiple leaf blocks
+#[case::node3("node3")]
 #[case::btree_2_with_xattrs("btree2.with-xattrs")]
 #[case::btree_2_3("btree2.3")]
 #[case::btree_3("btree3")]


### PR DESCRIPTION
    * Remove Dir3's generic parameter.  Put it on the methods instead.
    
    * Add a Directory enum, using static dispatch, instead of using a Dir3
      trait object, which uses dynamic dispatch.
    
    * Combine common code between all dir types.  The essential logic of
      next and lookup is the same.
    
    * Correctly distinguish between Leaf and Node directories.  I don't know
      where the original criteria came from, but it was wrong.  It led to us
      treating large Leaf directories as though they were Node directories,
      and that didn't work.
    
    * Fix lookup in small Node directories.  A very small Node directory may
      have a single leaf block, rather than a btree.
    
    Fixes #100
