### PR TITLE
Eliminate unaligned reads when using O_DIRECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Eliminated sector-size-unaligned reads when using `O_DIRECT`.
+  ([#112](https://github.com/KhaledEmaraDev/xfuse/pull/112))
+
 - Eliminated sector-size-unaligned reads from regular files greater than 8 kB in
   size.
-  ([#110](https://github.com/KhaledEmaraDev/xfuse/pull/107))
+  ([#110](https://github.com/KhaledEmaraDev/xfuse/pull/110))
 
 ## [0.2.0] - 2024-03-07
 

--- a/src/libxfuse/volume.rs
+++ b/src/libxfuse/volume.rs
@@ -179,10 +179,10 @@ impl Filesystem for Volume {
 
         let mut file = dinode.get_file(buf_reader.by_ref());
 
-        reply.data(
-            file.read(buf_reader.by_ref(), offset, size)
-                .as_slice(),
-        );
+        match file.read(buf_reader.by_ref(), offset, size) {
+            Ok((v, ignore)) => reply.data(&v[ignore..]),
+            Err(e) => reply.error(e)
+        }
     }
 
     fn release(


### PR DESCRIPTION
If xfs-fuse is mounting a device file, it's important to only read from the disk in whole sectors.  Previously we were relying on the OS cache to help with that.  Now, make it explicit.

Issue #111