### PR TITLE
Fix a crash when closing files in non-LIFO order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fixed a crash when opening and closing multiple files simultaneously but not
+  in LIFO order.
+  ([#116](https://github.com/KhaledEmaraDev/xfuse/pull/116))
+
 - Eliminated sector-size-unaligned reads when using `O_DIRECT`.
   ([#112](https://github.com/KhaledEmaraDev/xfuse/pull/112))
 


### PR DESCRIPTION
The original code tracked open files using a plain Vec.  That completely didn't work if multiple files were opened at once, unless they were closed in LIFO order.

Also, don't put anything in the FUSE filehandle.  We don't need it.