### PR TITLE
Cache directory's inodes during opendir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bincode = {version = "2.0.0-rc.3", default-features = false, features = ["derive
 byteorder = "1.4.3"
 crc = "2.0.0"
 enum_dispatch = "0.3.12"
-fuser = "0.13.0"
+fuser = { version = "0.13.0", features = ["abi-7-31"] }
 libc = "0.2.97"
 num-derive = "0.4.2"
 num-traits = "0.2.14"

--- a/benches/read-amplification.rs
+++ b/benches/read-amplification.rs
@@ -233,8 +233,8 @@ fn main() {
 
         let end_bytes = gnop.read_bytes();
         let total_bytes = end_bytes - start_bytes;
-        let ra = total_bytes / useful_bytes;
-        println!("{:19} {:20} {:19}x", bench.name, total_bytes, ra);
+        let ra = total_bytes as f64 / useful_bytes as f64;
+        println!("{:19} {:20} {:19.1}x", bench.name, total_bytes, ra);
         child.wait().unwrap();
     }
 }


### PR DESCRIPTION
This reduces the metadata benchmark's read amplification from 218.6x to 217.4x .