### PR TITLE
Simplify Volume::getxattr

### DIFF
--- a/src/libxfuse/attr_bptree.rs
+++ b/src/libxfuse/attr_bptree.rs
@@ -99,46 +99,6 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
         self.total_size.try_into().unwrap()
     }
 
-    fn get_size(&self, buf_reader: &mut R, super_block: &Sb, name: &OsStr) -> Result<u32, libc::c_int> {
-        let hash = hashname(name);
-
-        let blk = self.map_block(buf_reader.by_ref(), 0)?;
-        buf_reader
-            .seek(SeekFrom::Start(super_block.fsb_to_offset(blk)))
-            .unwrap();
-
-        let node = XfsDa3Intnode::from(buf_reader.by_ref(), super_block);
-
-        let blk = node.lookup(buf_reader.by_ref(), super_block, hash, |block, reader| {
-            self.map_block(reader.by_ref(), block.into()).unwrap()
-        }).map_err(|e| {
-            if e == libc::ENOENT {
-                libc::ENOATTR
-            } else {
-                e
-            }
-        })?;
-        let leaf_offset = super_block.fsb_to_offset(blk);
-
-        buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
-
-        loop {
-            let leaf: AttrLeafblock = decode_from(buf_reader.by_ref()).unwrap();
-
-            match leaf.get_size(hash) {
-                Ok(l) => return Ok(l),
-                Err(libc::ENOATTR) if leaf.entries.last().map(|e| e.hashval) == Some(hash) => {
-                    let forw = leaf.hdr.info.forw.into();
-                    let next_leaf_fsblock = self.map_block(buf_reader, forw)?;
-                    buf_reader.seek(SeekFrom::Start(super_block.fsb_to_offset(next_leaf_fsblock)))
-                        .unwrap();
-                    continue;
-                }
-                Err(e) => return Err(e)
-            }
-        }
-    }
-
     fn list(&mut self, buf_reader: &mut R, super_block: &Sb) -> Vec<u8> {
         let mut list: Vec<u8> =
             Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), super_block) as usize);
@@ -180,17 +140,17 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
 
         let blk = node.lookup(buf_reader.by_ref(), super_block, hash, |block, reader| {
             self.map_block(reader.by_ref(), block.into()).unwrap()
-        })?;
+        }).map_err(|e| if e == libc::ENOENT {libc::ENOATTR} else {e})?;
         let leaf_offset = super_block.fsb_to_offset(blk);
 
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 
         let leaf: AttrLeafblock = decode_from(buf_reader.by_ref()).unwrap();
 
-        return Ok(leaf.get(
+        return leaf.get(
             buf_reader.by_ref(),
             hash,
             |block, reader| self.map_block(reader.by_ref(), block).unwrap(),
-        ));
+        );
     }
 }

--- a/src/libxfuse/attr_leaf.rs
+++ b/src/libxfuse/attr_leaf.rs
@@ -73,12 +73,6 @@ impl<R: BufRead + Reader + Seek> Attr<R> for AttrLeaf {
         }
     }
 
-    fn get_size(&self, _buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> Result<u32, libc::c_int> {
-        let hash = hashname(name);
-
-        self.leaf.get_size(hash)
-    }
-
     fn list(&mut self, buf_reader: &mut R, super_block: &Sb) -> Vec<u8> {
         let mut list: Vec<u8> =
             Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), super_block) as usize);
@@ -91,11 +85,11 @@ impl<R: BufRead + Reader + Seek> Attr<R> for AttrLeaf {
     fn get(&self, buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> Result<Vec<u8>, i32> {
         let hash = hashname(name);
 
-        Ok(self.leaf.get(
+        self.leaf.get(
             buf_reader.by_ref(),
             hash,
             |block, _| self.map_logical_block_to_actual_block(block),
-        ))
+        )
     }
 }
 

--- a/src/libxfuse/attr_shortform.rs
+++ b/src/libxfuse/attr_shortform.rs
@@ -106,18 +106,6 @@ impl<R: BufRead + Seek> Attr<R> for AttrShortform {
         self.total_size
     }
 
-    fn get_size(&self, _buf_reader: &mut R, _super_block: &Sb, name: &OsStr) -> Result<u32, libc::c_int> {
-        for entry in &self.list {
-            let entry_name = entry.nameval[0..(entry.namelen as usize)].to_vec();
-
-            if name.as_bytes().to_vec() == entry_name {
-                return Ok(entry.valuelen.into());
-            }
-        }
-
-        Err(libc::ENOATTR)
-    }
-
     fn list(&mut self, buf_reader: &mut R, super_block: &Sb) -> Vec<u8> {
         let mut list: Vec<u8> =
             Vec::with_capacity(self.get_total_size(buf_reader.by_ref(), super_block) as usize);
@@ -143,6 +131,6 @@ impl<R: BufRead + Seek> Attr<R> for AttrShortform {
             }
         }
 
-        unreachable!("Volume::getxattr should've already verified that the attribute exists");
+        Err(libc::ENOATTR)
     }
 }


### PR DESCRIPTION
Since Attr::get allocates its own buffer, there's no need to precalculate the value's size.  We can simply get the whole value and then check the size.

This change both reduces SLOC and improves performance.  Read amplification for the xattr test drops from 5790.5x to 4425.5x .