### PR TITLE
Cache an inode's Directory object, if any.

### DIFF
--- a/src/libxfuse/dir3.rs
+++ b/src/libxfuse/dir3.rs
@@ -485,6 +485,7 @@ pub trait Dir3 {
     }
 }
 
+#[derive(Debug)]
 #[enum_dispatch::enum_dispatch(Dir3)]
 pub enum Directory {
     Sf(super::dir3_sf::Dir2Sf),

--- a/src/libxfuse/volume.rs
+++ b/src/libxfuse/volume.rs
@@ -115,24 +115,32 @@ impl Filesystem for Volume {
     fn lookup(&mut self, _req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
         let ttl = Duration::new(86400, 0);
         let mut buf_reader = BufReader::new(&self.device);
-        let dir = match self.open_files.get(&parent) {
-            Some(oi) => oi.dinode.get_dir(buf_reader.by_ref(), &self.sb),
+        let r = match self.open_files.get_mut(&parent) {
+            Some(oi) => {
+                let dir = oi.dinode.get_dir(buf_reader.by_ref(), &self.sb);
+                dir.lookup(
+                    BufReader::new(&self.device).by_ref(),
+                    &self.sb,
+                    name,
+                )
+            },
             None => {
                 let inode_number = if parent == FUSE_ROOT_ID {
                     self.sb.sb_rootino
                 } else {
                     parent as XfsIno
                 };
-                let dinode = Dinode::from(buf_reader.by_ref(), &self.sb, inode_number);
-                dinode.get_dir(buf_reader.by_ref(), &self.sb)
+                let mut dinode = Dinode::from(buf_reader.by_ref(), &self.sb, inode_number);
+                let dir = dinode.get_dir(buf_reader.by_ref(), &self.sb);
+                dir.lookup(
+                    BufReader::new(&self.device).by_ref(),
+                    &self.sb,
+                    name,
+                )
             }
         };
 
-        match dir.lookup(
-            BufReader::new(&self.device).by_ref(),
-            &self.sb,
-            name,
-        ) {
+        match r {
             Ok((attr, generation)) => {
                 reply.entry(&ttl, &attr, generation);
             }
@@ -243,7 +251,7 @@ impl Filesystem for Volume {
         mut reply: ReplyDirectory,
     ) {
         let mut buf_reader = BufReader::new(&self.device);
-        let oi = &self.open_files.get(&ino).unwrap();
+        let oi = &mut self.open_files.get_mut(&ino).unwrap();
 
         let dir = oi.dinode.get_dir(buf_reader.by_ref(), &self.sb);
 


### PR DESCRIPTION
    All directory types except shortform require reading additional disk
    blocks beyond the inode.  Since directories are very frequently accessed
    multiple times in succession, it makes sense to cache those blocks
    within the Inode, as long as the inode is alive.
    
    This especially benefits Leaf directories, reducing their read
    amplification by 5x to 18x, depending on the file name lengths.

Also, Split up the metadata benchmark
    
    Do a separate benchmark for each directory type.  Also, correct the
    inode size.  It was previously assumed to be 512B but it's actually
    1024B.