### PR TITLE
Switch inode lifecycle from open-close to lookup-inactive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,12 +428,9 @@ checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
-dependencies = [
- "cfg-if",
-]
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "matchers"
@@ -974,20 +971,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",


### PR DESCRIPTION
    This will result in more inodes being cached.  It will be especially
    effective for cases where multiple lookups happen but no readdir.  The
    downside is higher RAM consumption, because no inodes will be removed
    from cache unless the kernel experiences vnode pressure.
    
    As an aside, for a read-write file system this lifecycle is necessary in
    order to support open-but-deleted files.
    
    The reduction in Read Amplification is significant for metadata-heavy
    operations on small directories.  It's probably even greater for tests
    that do lookup without readdir, but there's no benchmark for that.
    
    For some benchmarks, the measured read amplification is now < 1.0x,
    which implies a calculation error, but I'll examine that later
    
    metadata-sf:            3.4x => 1.5x
    metadata-block:         2.2x => 0.3x
    metadata-leaf1k:        5.2x => 1.7x
    metadata-leaf4k:        2.0x => 0.2x
    metadata-node1:         8.9x => 5.4x
    metadata-node3:         12.9x => 9.4x
    all others:             slight, but positive.