### PR TITLE
Big improvements in metadata efficiency

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ task:
   matrix:
     - name: FreeBSD stable
       env:
-        VERSION: 1.73.0
+        VERSION: 1.74.0
     - name: FreeBSD nightly
       env:
         VERSION: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- The MSRV is now 1.74.0
+  ([#128](https://github.com/KhaledEmaraDev/xfuse/pull/128))
+
 ### Fixed
 
 - Fixed a crash when opening and closing multiple files simultaneously but not

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "xfs-fuse"
 description = "Read-only FUSE server implementing XFS"
 version = "0.2.1"
 edition = "2018"
+rust-version = "1.74"
 authors = ["Khaled Emara <mail@khaledemara.dev>"]
 repository = "https://github.com/KhaledEmaraDev/xfuse"
 license = "BSD-2-Clause"

--- a/src/libxfuse/attr_bptree.rs
+++ b/src/libxfuse/attr_bptree.rs
@@ -138,10 +138,11 @@ impl<R: Reader + BufRead + Seek> Attr<R> for AttrBtree {
 
         let node = XfsDa3Intnode::from(buf_reader.by_ref());
 
-        let blk = node.lookup(buf_reader.by_ref(), super_block, hash, |block, reader| {
+        let dablk = node.lookup(buf_reader.by_ref(), super_block, hash, |block, reader| {
             self.map_block(reader.by_ref(), block).unwrap()
         }).map_err(|e| if e == libc::ENOENT {libc::ENOATTR} else {e})?;
-        let leaf_offset = super_block.fsb_to_offset(blk);
+        let fsblock = self.map_block(buf_reader.by_ref(), dablk)?;
+        let leaf_offset = super_block.fsb_to_offset(fsblock);
 
         buf_reader.seek(SeekFrom::Start(leaf_offset)).unwrap();
 

--- a/src/libxfuse/da_btree.rs
+++ b/src/libxfuse/da_btree.rs
@@ -198,6 +198,7 @@ impl XfsDa3Intnode {
                 .seek(SeekFrom::Start(offset))
                 .unwrap();
 
+            eprint!("1");
             let node = XfsDa3Intnode::from(buf_reader.by_ref());
             node.lookup(
                 buf_reader.by_ref(),

--- a/src/libxfuse/dinode.rs
+++ b/src/libxfuse/dinode.rs
@@ -408,11 +408,7 @@ impl Dinode {
                 }
             }
             Some(DiA::Abmbt((bmdr, keys, pointers))) => Some(Box::new(AttrBtree {
-                btree: BtreeRoot {
-                    bmdr: bmdr.clone(),
-                    keys: keys.clone(),
-                    ptrs: pointers.clone(),
-                },
+                btree: BtreeRoot::new(bmdr.clone(), keys.clone(), pointers.clone()),
                 total_size: -1,
             })),
             None => None,

--- a/src/libxfuse/dir3.rs
+++ b/src/libxfuse/dir3.rs
@@ -246,9 +246,10 @@ impl Leaf {
         match self {
             Leaf::LeafN(leafn) => Ok(leafn),
             Leaf::Btree(btree) => {
-                let fsblock: XfsFsblock = btree.lookup(buf_reader.by_ref(), sb, hash,
+                let dablk: XfsDablk = btree.lookup(buf_reader.by_ref(), sb, hash,
                     |block, br| dir.map_dblock(br, block).unwrap()
                 )?;
+                let fsblock = dir.map_dblock(buf_reader.by_ref(), dablk)?;
                 buf_reader.seek(SeekFrom::Start(sb.fsb_to_offset(fsblock))).unwrap();
                 Ok(decode_from(buf_reader.by_ref()).unwrap())
             }


### PR DESCRIPTION
The main effect of these changes is to cache most types of metadata block within their inodes, for the lifetime of the inode.

Read amplification improvements:
```md
     Benchmark       Before   After 
=================== ======== =======
metadata-sf            1.0x    1.0x
metadata-block         1.5x    1.5x
metadata-leaf1k        2.7x    1.6x
metadata-leaf4k        1.2x    1.1x
metadata-node1        10.7x    1.6x
metadata-node3        18.7x    1.6x
metadata-btree2.3     52.4x    1.6x
metadata-btree3       89.1x    1.6x
data-fragmented-1k     3.0x    1.0x
data-fragmented-4k     2.7x    1.1x
data-sequential-1k     1.0x    1.0x
data-sequential-4k     1.0x    1.0x
xattr                553.1x  547.8x
```
This also results in about a 3x reduction in runtime, on my hardware, to run the read-amplification benchmark.