### PR TITLE
Prefer shift to multiply

### DIFF
--- a/src/libxfuse/dinode.rs
+++ b/src/libxfuse/dinode.rs
@@ -100,9 +100,9 @@ impl Dinode {
             (inode_number >> superblock.sb_inopblog) & ((1 << superblock.sb_agblklog) - 1);
         let blk_ino = inode_number & ((1 << superblock.sb_inopblog) - 1);
 
-        let off = ag_no * u64::from(superblock.sb_agblocks) * u64::from(superblock.sb_blocksize)
-            + ag_blk * u64::from(superblock.sb_blocksize)
-            + blk_ino * u64::from(superblock.sb_inodesize);
+        let off: u64 = ((ag_no * u64::from(superblock.sb_agblocks)) << superblock.sb_blocklog)
+            + (ag_blk << superblock.sb_blocklog)
+            + (blk_ino << superblock.sb_inodelog);
 
         buf_reader.seek(SeekFrom::Start(off)).unwrap();
         let mut raw = vec![0u8; superblock.sb_inodesize.into()];

--- a/src/libxfuse/dir3_leaf.rs
+++ b/src/libxfuse/dir3_leaf.rs
@@ -97,7 +97,7 @@ impl Dir2Leaf {
         }
         let offset = superblock.fsb_to_offset(leaf_extent.br_startblock);
 
-        let leaf_size = leaf_extent.br_blockcount as usize * superblock.sb_blocksize as usize;
+        let leaf_size = (leaf_extent.br_blockcount as usize) << superblock.sb_blocklog;
         let leaf = Dir2LeafDisk::from(buf_reader, offset, leaf_size);
         assert_eq!(leaf.hdr.info.magic, XFS_DIR3_LEAF1_MAGIC);
 

--- a/src/libxfuse/sb.rs
+++ b/src/libxfuse/sb.rs
@@ -100,7 +100,7 @@ pub struct Sb {
     // sb_fname: [u8; 12],
     pub sb_blocklog: u8,
     // sb_sectlog: u8,
-    // sb_inodelog: u8,
+    pub sb_inodelog: u8,
     pub sb_inopblog: u8,
     pub sb_agblklog: u8,
     // sb_rextslog: u8,
@@ -164,7 +164,7 @@ impl Sb {
 
         let sb_blocklog = buf_reader.read_u8().unwrap();
         let _sb_sectlog = buf_reader.read_u8().unwrap();
-        let _sb_inodelog = buf_reader.read_u8().unwrap();
+        let sb_inodelog = buf_reader.read_u8().unwrap();
         let sb_inopblog = buf_reader.read_u8().unwrap();
         let sb_agblklog = buf_reader.read_u8().unwrap();
         let _sb_rextslog = buf_reader.read_u8().unwrap();
@@ -232,6 +232,7 @@ impl Sb {
             sb_logblocks,
             sb_inodesize,
             sb_blocklog,
+            sb_inodelog,
             sb_inopblog,
             sb_agblklog,
             sb_icount,


### PR DESCRIPTION
The code use to contain main expressions of the form "X * sb_blocksize". This commit removes the last of them, replacing them with "X << sb_blocklog", which is faster.

Fixes #103