### PR TITLE
Better error checks for file systems with unsupported features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Better error messages when attempting to mount a file system with unsupported features.
+  ([#147](https://github.com/KhaledEmaraDev/xfuse/issues/147))
+
 ## [0.4.0] - 2024-05-30
 
 ### Added


### PR DESCRIPTION
When attempting to mount a file system with an unknown or unsupported feature in the superblock, immediately print an error and abort.