### PR TITLE
File methods don't need &mut self

### DIFF
--- a/src/libxfuse/file.rs
+++ b/src/libxfuse/file.rs
@@ -44,10 +44,10 @@ pub trait File<R: BufRead + Reader + Seek> {
     fn get_extent(&self, buf_reader: &mut R, block: XfsFileoff) -> (Option<XfsFsblock>, u64);
 
     /// Like lseek(2), but only works for SEEK_HOLE and SEEK_DATA
-    fn lseek(&mut self, buf_reader: &mut R, offset: u64, whence: i32) -> Result<u64, i32>;
+    fn lseek(&self, buf_reader: &mut R, offset: u64, whence: i32) -> Result<u64, i32>;
 
     /// Perform a sector-size aligned read of the file
-    fn read_sectors(&mut self, buf_reader: &mut R, offset: i64, mut size: usize)
+    fn read_sectors(&self, buf_reader: &mut R, offset: i64, mut size: usize)
         -> Result<Vec<u8>, i32>
     {
         let sb = SUPERBLOCK.get().unwrap();
@@ -91,7 +91,7 @@ pub trait File<R: BufRead + Reader + Seek> {
 
     /// Return from a file.  Return a buffer containing the requested data, plus a number of bytes
     /// that the caller should ignore from the head of the vector.
-    fn read(&mut self, buf_reader: &mut R, offset: i64, size: u32) -> Result<(Vec<u8>, usize), i32>
+    fn read(&self, buf_reader: &mut R, offset: i64, size: u32) -> Result<(Vec<u8>, usize), i32>
     {
         let sb = SUPERBLOCK.get().unwrap();
         let size = u32::try_from(i64::from(size).min(self.size() - offset)).unwrap();

--- a/src/libxfuse/file_btree.rs
+++ b/src/libxfuse/file_btree.rs
@@ -50,7 +50,7 @@ impl<R: BufRead + Reader + Seek> File<R> for FileBtree {
         (start, len)
     }
 
-    fn lseek(&mut self, buf_reader: &mut R, offset: u64, whence: i32) -> Result<u64, i32> {
+    fn lseek(&self, buf_reader: &mut R, offset: u64, whence: i32) -> Result<u64, i32> {
         let sb = SUPERBLOCK.get().unwrap();
 
         let mut dblock = offset >> sb.sb_blocklog;

--- a/src/libxfuse/file_extent_list.rs
+++ b/src/libxfuse/file_extent_list.rs
@@ -50,7 +50,7 @@ impl<R: BufRead + Reader + Seek> File<R> for FileExtentList {
         (start, len)
     }
 
-    fn lseek(&mut self, _buf_reader: &mut R, offset: u64, whence: i32) -> Result<u64, i32> {
+    fn lseek(&self, _buf_reader: &mut R, offset: u64, whence: i32) -> Result<u64, i32> {
         let sb = SUPERBLOCK.get().unwrap();
 
         let dblock = offset >> sb.sb_blocklog;

--- a/src/libxfuse/volume.rs
+++ b/src/libxfuse/volume.rs
@@ -157,7 +157,7 @@ impl Filesystem for Volume {
 
         let oi = &self.open_files.get(&ino).unwrap();
         let mut buf_reader = BufReader::with_capacity(self.sb.sb_blocksize as usize, &self.device);
-        let mut file = oi.dinode.get_file(buf_reader.by_ref());
+        let file = oi.dinode.get_file(buf_reader.by_ref());
         if offset > file.size() {
             reply.error(libc::ENXIO);
             return;
@@ -245,7 +245,7 @@ impl Filesystem for Volume {
         let oi = &self.open_files.get(&ino).unwrap();
         let mut buf_reader = BufReader::with_capacity(self.sb.sb_blocksize as usize, &self.device);
 
-        let mut file = oi.dinode.get_file(buf_reader.by_ref());
+        let file = oi.dinode.get_file(buf_reader.by_ref());
 
         match file.read(buf_reader.by_ref(), offset, size) {
             Ok((v, ignore)) => reply.data(&v[ignore..]),


### PR DESCRIPTION
I don't know why they take a mutable receiver.  It dates to 30684f67, but it doesn't look like it was necessary even then.