### PR TITLE
minor maintenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Khaled Emara <mail@khaledemara.dev>"]
 repository = "https://github.com/KhaledEmaraDev/xfuse"
 license = "BSD-2-Clause"
 categories = ["filesystem"]
+keywords = ["xfs", "fuse", "filesystem"]
 exclude = [
   "/.gitignore",
   "/.cirrus.yml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xfs-fuse"
 description = "Read-only FUSE server implementing XFS"
 version = "0.4.2"
-edition = "2018"
+edition = "2021"
 rust-version = "1.74"
 authors = ["Khaled Emara <mail@khaledemara.dev>"]
 repository = "https://github.com/KhaledEmaraDev/xfuse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2.97"
 num-derive = "0.4.2"
 num-traits = "0.2.14"
 tracing = "0.1.37"
-uuid = "0.8.2"
+uuid = "1.0"
 
 [[test]]
 name = "integration"

--- a/src/libxfuse/dir3.rs
+++ b/src/libxfuse/dir3.rs
@@ -25,7 +25,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-use std::convert::TryInto;
 use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, Seek};
 use std::os::unix::ffi::OsStringExt;

--- a/src/libxfuse/dir3_lf.rs
+++ b/src/libxfuse/dir3_lf.rs
@@ -25,7 +25,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-use std::convert::TryInto;
 use std::ffi::{OsStr, OsString};
 use std::ops::Range;
 

--- a/src/libxfuse/file.rs
+++ b/src/libxfuse/file.rs
@@ -27,7 +27,6 @@
  */
 use std::{
     cmp::min,
-    convert::TryFrom,
     io::{BufRead, Seek, SeekFrom}
 };
 

--- a/src/libxfuse/volume.rs
+++ b/src/libxfuse/volume.rs
@@ -26,7 +26,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{BufReader, Read};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     ffi::{OsStr, OsString},
     fs,
     io::{self, ErrorKind, Read},
@@ -506,7 +505,7 @@ mod getextattr {
 #[named]
 #[apply(all_xattr_fork_types)]
 fn getextattr_size(#[case] h: fn() -> Harness, #[case] d: &str) {
-    use std::{convert::TryFrom, ffi::CString, ptr};
+    use std::{ffi::CString, ptr};
 
     require_fusefs!();
 
@@ -859,7 +858,7 @@ mod lsextattr {
     #[named]
     #[rstest]
     fn empty(harness4k: Harness) {
-        use std::{convert::TryFrom, ffi::CString};
+        use std::ffi::CString;
         require_fusefs!();
 
         let ns = libc::EXTATTR_NAMESPACE_USER;
@@ -885,7 +884,7 @@ mod lsextattr {
     #[named]
     #[rstest]
     fn empty_size(harness4k: Harness) {
-        use std::{convert::TryFrom, ffi::CString, ptr};
+        use std::{ffi::CString, ptr};
         require_fusefs!();
 
         let ns = libc::EXTATTR_NAMESPACE_USER;
@@ -915,7 +914,7 @@ mod lsextattr {
     #[named]
     #[apply(all_xattr_fork_types)]
     fn size(#[case] h: fn() -> Harness, #[case] d: &str) {
-        use std::{convert::TryFrom, ffi::CString, ptr};
+        use std::{ffi::CString, ptr};
         require_fusefs!();
 
         let harness = h();


### PR DESCRIPTION
- Use the stable UUID release
- Add crates.io keywords
- Convert to 2021 edition