### PR TITLE
Compatibility with cargo's new -Zbuild-dir feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,13 +62,14 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.11"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d6b683edf8d1119fe420a94f8a7e389239666aa72e65495d91c00462510151"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
 dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
+ "libc",
  "predicates",
  "predicates-core",
  "predicates-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ default-features = false
 features = [ "ansi", "env-filter", "fmt", "tracing-log" ]
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd = "2.0.17"
 function_name = "0.3.0"
 mdconfig = "0.2.0"
 rstest = "0.19.0"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,7 +15,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::cargo::CommandCargoExt;
+use assert_cmd::cargo::cargo_bin;
 use function_name::named;
 use nix::{
     errno::Errno,
@@ -125,8 +125,7 @@ struct Harness {
 
 fn harness(img: &Path) -> Harness {
     let d = tempdir().unwrap();
-    let child = Command::cargo_bin("xfs-fuse")
-        .unwrap()
+    let child = Command::new(cargo_bin!("xfs-fuse"))
         .arg(img)
         .arg(d.path())
         .spawn()
@@ -323,8 +322,7 @@ mod dev {
             .create()
             .unwrap();
         let d = tempdir().unwrap();
-        let child = Command::cargo_bin("xfs-fuse")
-            .unwrap()
+        let child = Command::new(cargo_bin!("xfs-fuse"))
             .arg(md.path())
             .arg(d.path())
             .spawn()


### PR DESCRIPTION
Need to update assert_cmd to know how to find the binaries when -Zbuild-dir is in use.