### PR TITLE
By default, run in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+- By default, xfs-fuse now runs in the background, like most FUSE servers.
+  Legacy behavior (running in the foreground) can be achieved with `-f`.
+  ([#175](https://github.com/KhaledEmaraDev/xfuse/issues/175))
+
 ## [0.4.4] - 2024-08-15
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ crc = "2.0.0"
 enum_dispatch = "0.3.12"
 fuser = { version = "0.13.0", features = ["abi-7-31"] }
 libc = "0.2.154"
-nix = { version = "0.27.0", features = [ "ioctl" ] }
+nix = { version = "0.27.0", features = [ "ioctl", "process" ] }
 num-derive = "0.4.2"
 num-traits = "0.2.14"
 tracing = "0.1.37"

--- a/doc/xfs-fuse.1
+++ b/doc/xfs-fuse.1
@@ -1,4 +1,4 @@
-.Dd August 26, 2021
+.Dd July 15, 2025
 .Dt XFUSE 1
 .Os
 .Sh NAME
@@ -6,24 +6,30 @@
 .Nd Mount an XFS filesystem
 .Sh SYNOPSIS
 .Nm
-.Op Ar device
-.Op Ar mountpoint
+.Op Fl fhV
+.Op Fl o Ar options
+.Ar device
+.Ar mountpoint
 .Sh DESCRIPTION
 .Nm
-can be used to attach an XFS filesystem found on
+can be used to mount an XFS filesystem found on
 .Ar device
 to
-.Ar mountpoint
-in the unix filesystem tree.
+.Ar mountpoint .
 .Pp
 The options are as follows:
 .Bl -tag -width indent
-.It Ar device
-The device that carries the XFS filesystem data.
-.It Ar mountpoint
-The path in the current unix filesystem tree to attach
-.Ar device
-to.
+.It Fl f
+Run in the foreground instead of daemonizing.
+.It Fl o
+Pass various common options to the kernel.
+See
+.Xr mount_fusefs 8
+for the list.
+.It Fl h , -help
+Print usage information and exit.
+.It Fl V , -version
+Print the version and exit.
 .El
 .Pp
 .El

--- a/src/libxfuse/bmbt_rec.rs
+++ b/src/libxfuse/bmbt_rec.rs
@@ -27,16 +27,8 @@
  */
 
 use bincode::{de::Decoder, error::DecodeError, Decode};
-use num_derive::FromPrimitive;
 
 use super::{definitions::*, volume::SUPERBLOCK};
-
-#[derive(Debug, FromPrimitive, Clone)]
-pub enum XfsExntst {
-    Norm,
-    Unwritten,
-    Invalid,
-}
 
 #[derive(Debug, Clone, Copy)]
 pub struct BmbtRec {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use std::path::PathBuf;
 use clap::{crate_version, Parser};
 use fuser::{mount2, MountOption};
 use libxfuse::volume::Volume;
+use nix::unistd::daemon;
 use tracing_subscriber::EnvFilter;
 
 mod libxfuse;
@@ -42,6 +43,10 @@ struct App {
     options:    Vec<String>,
     device:     PathBuf,
     mountpoint: String,
+
+    /// Run in the foreground
+    #[arg(short)]
+    foreground: bool,
 }
 
 fn main() {
@@ -85,5 +90,8 @@ fn main() {
 
     let vol = Volume::from(&app.device);
 
+    if !app.foreground {
+        daemon(false, false).unwrap();
+    }
     mount2(vol, app.mountpoint, &opts[..]).unwrap();
 }


### PR DESCRIPTION
To run in the foreground, add "-f".  This is in keeping with the convention used by most fuse file systems.