### PR TITLE
Support version 1 inodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added support for version 1 extended attributes.
   ([#190](https://github.com/KhaledEmaraDev/xfuse/issues/190))
 
+- Added support for version 1 inodes.
+  ([#191](https://github.com/KhaledEmaraDev/xfuse/issues/190))
+
 ## [0.6.0] - 2026-03-09
 
 ### Added

--- a/src/libxfuse/dinode.rs
+++ b/src/libxfuse/dinode.rs
@@ -36,6 +36,7 @@ use bincode_next::{
     Decode,
 };
 use libc::{mode_t, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK};
+use tracing::warn;
 
 use super::{
     attr::Attributes,
@@ -120,7 +121,18 @@ impl Dinode {
         let di_core = DinodeCore::decode(&mut decoder).unwrap();
 
         let di_u: Option<DiU>;
-        match (di_core.di_mode as mode_t) & S_IFMT {
+        let effective_mode = if di_core.di_mode == 0 {
+            // SGI XFS file systems sometimes have corrupt inodes with a mode of 0 . Treat them
+            // like regular files, which they all appear to be
+            warn!(
+                "Unknown inode type {:#o} for inode {inode_number}",
+                di_core.di_mode
+            );
+            S_IFREG
+        } else {
+            (di_core.di_mode as mode_t) & S_IFMT
+        };
+        match effective_mode {
             S_IFREG => match di_core.di_format {
                 XfsDinodeFmt::Extents => {
                     let mut bmx = Vec::<BmbtRec>::new();
@@ -302,7 +314,7 @@ impl Dinode {
         self.directory.as_ref().unwrap()
     }
 
-    pub fn get_file(&mut self) -> &FileMetadata {
+    pub fn get_file(&mut self) -> Result<&FileMetadata, i32> {
         if self.file.is_none() {
             self.file = Some(match &self.di_u {
                 DiU::Bmx(bmx) => {
@@ -319,12 +331,10 @@ impl Dinode {
                     };
                     FileMetadata::Btree(fbt)
                 }
-                _ => {
-                    panic!("Unsupported file format!");
-                }
+                _ => return Err(libc::ENXIO),
             });
         }
-        self.file.as_ref().unwrap()
+        Ok(self.file.as_ref().unwrap())
     }
 
     pub fn get_link_data<R>(&self, buf_reader: &mut R, superblock: &Sb) -> CString
@@ -403,7 +413,7 @@ impl Dinode {
         let mut logical_block = u64::try_from(offset >> sb.sb_blocklog).unwrap();
         let mut block_offset: u64 = 0;
 
-        let file_metadata = self.get_file();
+        let file_metadata = self.get_file()?;
         while size > 0 {
             let (blk, blocks) = (*file_metadata).get_extent(buf_reader.by_ref(), logical_block);
             let z = usize::try_from(min(
@@ -449,7 +459,7 @@ impl Dinode {
     where
         R: BufRead + Reader + Seek,
     {
-        let md = self.get_file();
+        let md = self.get_file()?;
         md.lseek(buf_reader, offset, whence)
     }
 
@@ -489,7 +499,6 @@ impl Dinode {
 
     /// The size in bytes of the associated regular file, if any exists
     pub fn fsize(&mut self) -> XfsFsize {
-        let md = self.get_file();
-        md.size()
+        self.get_file().map(FileMetadata::size).unwrap_or(0)
     }
 }

--- a/src/libxfuse/dinode_core.rs
+++ b/src/libxfuse/dinode_core.rs
@@ -98,7 +98,8 @@ pub struct DinodeCore {
     //_di_onlink: u16,
     pub di_uid:     u32,
     pub di_gid:     u32,
-    pub di_nlink:   u32,
+    //_di_nlink:   u32,
+    nlink:          u32,
     //_di_projid: u16,
     //_di_projid_hi: u16,
     //_di_pad: [u8; 6],
@@ -214,7 +215,7 @@ impl DinodeCore {
             crtime: self.timestamp(&self.di_crtime),
             kind,
             perm: self.di_mode & !S_IFMT,
-            nlink: self.di_nlink,
+            nlink: self.nlink,
             uid: self.di_uid,
             gid: self.di_gid,
             rdev: 0,
@@ -251,15 +252,16 @@ impl<Ctx> Decode<Ctx> for DinodeCore {
         assert_eq!(di_magic, XFS_DINODE_MAGIC, "Inode magic number is invalid");
         let di_mode: u16 = Decode::decode(decoder)?;
         let di_version: i8 = Decode::decode(decoder)?;
-        assert!(
-            di_version == 2 || di_version == 3,
-            "Only inode versions 2 and 3 are supported"
-        );
         let di_format: XfsDinodeFmt = Decode::decode(decoder)?;
-        let _di_onlink: u16 = Decode::decode(decoder)?;
+        let di_onlink: u16 = Decode::decode(decoder)?;
         let di_uid: u32 = Decode::decode(decoder)?;
         let di_gid: u32 = Decode::decode(decoder)?;
         let di_nlink: u32 = Decode::decode(decoder)?;
+        let nlink: u32 = if di_version == 1 {
+            di_onlink.into()
+        } else {
+            di_nlink
+        };
         let _di_projid: u16 = Decode::decode(decoder)?;
         let _di_projid_hi: u16 = Decode::decode(decoder)?;
         let di_maybe_big_nextents: u64 = Decode::decode(decoder)?;
@@ -306,7 +308,7 @@ impl<Ctx> Decode<Ctx> for DinodeCore {
             di_format,
             di_uid,
             di_gid,
-            di_nlink,
+            nlink,
             di_atime,
             di_mtime,
             di_ctime,

--- a/src/libxfuse/utils.rs
+++ b/src/libxfuse/utils.rs
@@ -108,10 +108,11 @@ pub fn get_file_type(kind: FileKind) -> Result<FileType, c_int> {
             S_IFCHR => Ok(FileType::CharDevice),
             S_IFBLK => Ok(FileType::BlockDevice),
             S_IFIFO => Ok(FileType::NamedPipe),
-            _ => {
-                error!("Unknown file type {:?}.", (file_mode as mode_t) & S_IFMT);
-                Err(ENOENT)
-            }
+            // TODO: add a FileType::unknown to fuser
+            // https://github.com/cberner/fuser/issues/685
+            // Until fuser gains that feature, the best that we can do is to report these corrupt
+            // inodes as some other type of file.
+            _ => Ok(FileType::RegularFile),
         },
     }
 }


### PR DESCRIPTION
The Linux XFS driver ceased writing such inodes decades ago, and eventually ceased to even support reading them.  But they aren't so different from version 2 inodes.

XFS file systems formatted by Irix 6.5 sometimes contains files with a mode of 0 and nlink of 0.  Obviously, they aren't valid.  But they're there.  We'll treat them like regular files, but warn the user about them.

I can't easily create a test file system image with version 1 inodes, so I tested this change on several real Irix 6.5-formatted file systems.